### PR TITLE
refactor(config): support loading and saving config as JSON

### DIFF
--- a/novel_downloader/config/loader.py
+++ b/novel_downloader/config/loader.py
@@ -10,9 +10,10 @@ dictionaries, with robust error handling and fallback support.
 This is typically used to load user-supplied or internal default config files.
 """
 
+import json
 import logging
-import shutil
 from importlib.abc import Traversable
+from importlib.resources import as_file
 from pathlib import Path
 from typing import Any, Dict, Optional, Union
 
@@ -82,17 +83,28 @@ def load_config(config_path: Optional[Union[str, Path]]) -> Dict[str, Any]:
         logger.warning("[config] No valid config file found, using empty config.")
         return {}
 
-    try:
-        content = path.read_text(encoding="utf-8")
-    except Exception as e:
-        logger.error("[config] Failed to read config file '%s': %s", path, e)
-        return {}
+    with as_file(path) as real_path:
+        try:
+            content = real_path.read_text(encoding="utf-8")
+            ext = real_path.suffix.lower()
+        except Exception as e:
+            logger.error("[config] Failed to read config file '%s': %s", path, e)
+            return {}
 
-    try:
-        data = yaml.safe_load(content)
-    except yaml.YAMLError as e:
-        logger.error("[config] YAML parse error in '%s': %s", path, e)
-        return {}
+    data: Any = None
+
+    if ext == ".json":
+        try:
+            data = json.loads(content)
+        except json.JSONDecodeError as e:
+            logger.error("[config] JSON parse error in '%s': %s", path, e)
+            return {}
+    else:
+        try:
+            data = yaml.safe_load(content)
+        except yaml.YAMLError as e:
+            logger.error("[config] YAML parse error in '%s': %s", path, e)
+            return {}
 
     if data is None:
         return {}
@@ -108,10 +120,12 @@ def load_config(config_path: Optional[Union[str, Path]]) -> Dict[str, Any]:
 
 
 def save_config_file(
-    source_path: Union[str, Path], output_path: Union[str, Path] = SETTING_FILE
+    source_path: Union[str, Path],
+    output_path: Union[str, Path] = SETTING_FILE,
 ) -> None:
     """
-    Validate a YAML config file and copy it to the application's setting path.
+    Validate a YAML/JSON config file, load it into a dict,
+    and then dump it as JSON to the internal SETTING_FILE.
 
     :param source_path: The user-provided YAML file path.
     :param output_path: Destination path to save the config (default: SETTING_FILE).
@@ -122,24 +136,42 @@ def save_config_file(
     if not source.is_file():
         raise FileNotFoundError(f"Source file not found: {source}")
 
-    if source.suffix.lower() not in {".yaml", ".yml"}:
-        raise ValueError(f"Source file must be a .yaml or .yml: {source}")
+    ext = source.suffix.lower()
 
-    logger.debug("[config] Checking YAML validity: %s", source)
+    if ext in {".yaml", ".yml"}:
+        logger.debug("[config] Loading YAML for conversion: %s", source)
+        try:
+            with source.open("r", encoding="utf-8") as f:
+                data = yaml.safe_load(f)
+        except yaml.YAMLError as e:
+            logger.error("[config] Invalid YAML format: %s", e)
+            raise ValueError(f"Invalid YAML file: {source}") from e
 
-    try:
-        with source.open("r", encoding="utf-8") as f:
-            yaml.safe_load(f)
-    except Exception as e:
-        logger.error("[config] Invalid YAML format: %s", e)
-        raise ValueError(f"Invalid YAML file: {source}") from e
+    elif ext == ".json":
+        logger.debug("[config] Loading JSON for saving: %s", source)
+        try:
+            with source.open("r", encoding="utf-8") as f:
+                data = json.load(f)
+        except json.JSONDecodeError as e:
+            logger.error("[config] Invalid JSON format: %s", e)
+            raise ValueError(f"Invalid JSON file: {source}") from e
 
-    logger.debug("[config] YAML validated, saving to %s", output)
+    else:
+        raise ValueError(f"Source file must be .yaml, .yml, or .json: {source}")
+
+    if not isinstance(data, dict):
+        raise ValueError(f"Config root must be a JSON/YAML object: {source}")
 
     output.parent.mkdir(parents=True, exist_ok=True)
-    shutil.copy2(source, output)
+    try:
+        with output.open("w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2, ensure_ascii=False)
+    except Exception as e:
+        logger.error("[config] Failed to write config JSON '%s': %s", output, e)
+        raise
 
-    logger.info("[config] Setting file successfully updated: %s", output)
+    logger.info("[config] Configuration successfully saved to JSON: %s", output)
+    return
 
 
 __all__ = ["load_config"]

--- a/novel_downloader/utils/constants.py
+++ b/novel_downloader/utils/constants.py
@@ -42,7 +42,7 @@ MODEL_CACHE_DIR = BASE_CONFIG_DIR / "models"
 # -----------------------------------------------------------------------------
 STATE_FILE = STATE_DIR / "state.json"
 HASH_STORE_FILE = DATA_DIR / "image_hashes.json"
-SETTING_FILE = CONFIG_DIR / "settings.yaml"
+SETTING_FILE = CONFIG_DIR / "settings.json"
 SITE_RULES_FILE = CONFIG_DIR / "site_rules.json"
 DEFAULT_USER_DATA_DIR = DATA_DIR / "browser_data"
 


### PR DESCRIPTION
This PR refactors the configuration loader:
- Refactor config loader to support both YAML and JSON
- Internally save config as JSON to SETTING_FILE
- Maintains compatibility with YAML sources

This simplifies internal config handling and enables future CLI improvements.