### PR TITLE
ci(bump): add bump and tag workflows for automated versioning

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -1,0 +1,42 @@
+name: Bump Version
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump_type:
+        description: 'Version bump type: patch, minor, major'
+        required: true
+        default: 'patch'
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install commitizen
+
+      - name: Bump version (no tag)
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          cz bump --yes --no-tag --increment ${{ github.event.inputs.bump_type }}
+
+          VERSION=$(cz version --project)
+          BRANCH="chore/bump/v$VERSION"
+
+          git checkout -b "$BRANCH"
+          git push origin "$BRANCH"
+
+          echo "Version bumped to $VERSION and pushed to branch $BRANCH"

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,0 +1,27 @@
+name: Tag After Bump
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  tag:
+    if: "${{ startsWith(github.event.head_commit.message, 'chore(release): bump version to') }}"
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Extract version from commit message
+        id: extract
+        run: |
+          VERSION=$(echo "${{ github.event.head_commit.message }}" | grep -oP 'bump version to \K[0-9]+\.[0-9]+\.[0-9]+')
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Create and push tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "v${{ steps.extract.outputs.version }}"
+          git push origin "v${{ steps.extract.outputs.version }}"


### PR DESCRIPTION
This PR introduces two GitHub Actions workflows:

- `bump.yml`: Manually triggered workflow to bump version, update changelog and version files, and push to a dedicated version branch (e.g. `chore/bump/v1.2.3`)
- `tag.yml`: Automatically creates a Git tag on the `main` branch when a version bump commit is merged, based on the format `chore(release): bump version to x.y.z`.