### PR TITLE
refactor(config): unify time fields as float + centralize font OCR config

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,12 +7,12 @@ assignees: ''
 
 ---
 
-**Describe the bug / 描述问题**  
-A clear and concise description of what the bug is.  
+**Describe the bug / 描述问题**
+A clear and concise description of what the bug is.
 请简要描述你遇到的问题或异常。
 
-**To Reproduce / 重现步骤**  
-Steps to reproduce the behavior:  
+**To Reproduce / 重现步骤**
+Steps to reproduce the behavior:
 如何重现该问题的操作步骤：
 
 1. Go to '...'
@@ -20,22 +20,22 @@ Steps to reproduce the behavior:
 3. Observe the output
 4. See error
 
-**Expected behavior / 预期行为**  
-A clear and concise description of what you expected to happen.  
+**Expected behavior / 预期行为**
+A clear and concise description of what you expected to happen.
 你希望程序本应如何运行？
 
-**Actual behavior / 实际行为**  
-What actually happened instead of the expected behavior?  
+**Actual behavior / 实际行为**
+What actually happened instead of the expected behavior?
 程序实际运行的结果是什么？有报错信息请贴上来。
 
-**Environment / 运行环境信息**  
-Please provide details about your system.  
+**Environment / 运行环境信息**
+Please provide details about your system.
 请提供你的系统相关信息：
 
 - OS: (e.g. Windows 11, macOS 14, Ubuntu 22.04)
 - Python version: (e.g. 3.10.5)
 - novel_downloader version: (e.g. 0.3.1)
 
-**Additional context / 补充信息**  
-Add any other context about the problem here.  
+**Additional context / 补充信息**
+Add any other context about the problem here.
 如果有其他相关背景（如是否使用代理、自定义配置等），可以在这里说明。

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,18 +7,18 @@ assignees: ''
 
 ---
 
-**Is your feature request related to a problem? Please describe. / 此功能请求是否与某个问题相关？**  
-A clear and concise description of what the problem is.  
+**Is your feature request related to a problem? Please describe. / 此功能请求是否与某个问题相关？**
+A clear and concise description of what the problem is.
 请描述你遇到的问题或限制（如有）
 
 **Describe the feature you'd like / 描述你希望添加的功能**
-A clear and concise description of what you want to happen.  
+A clear and concise description of what you want to happen.
 你希望添加什么功能？它应该怎么工作？
 
-**Describe alternatives you've considered / 你考虑过的替代方案**  
-A clear and concise description of any alternative solutions or features you've considered.  
+**Describe alternatives you've considered / 你考虑过的替代方案**
+A clear and concise description of any alternative solutions or features you've considered.
 是否有其他实现方式？
 
-**Additional context / 补充信息**  
-Add any other context or CLI example here.  
+**Additional context / 补充信息**
+Add any other context or CLI example here.
 比如使用示例、参数设计、配置项，返回什么结果等。

--- a/docs/4-settings-schema.md
+++ b/docs/4-settings-schema.md
@@ -4,11 +4,11 @@
 
 | 参数名            | 类型    | 默认值          | 说明                                   |
 |------------------|--------|---------------|--------------------------------------|
-| `wait_time`        | int    | 5             | 每次请求等待时间 (秒)                     |
-| `retry_times`      | int    | 3             | 请求失败重试次数                          |
-| `retry_interval`   | int    | 5             | 重试间隔 (秒)                           |
-| `timeout`          | int    | 30            | 页面加载超时时间 (秒)                     |
-| `max_rps`           | int \| null | null  | 最大请求速率（requests per second），为 `null` 则不限制 |
+| `wait_time`        | float  | 5.0           | 每次请求等待时间 (秒)                    |
+| `retry_times`      | int    | 3             | 请求失败重试次数                         |
+| `retry_interval`   | float  | 5.0           | 重试间隔 (秒)                           |
+| `timeout`          | float  | 30.0          | 页面加载超时时间 (秒)                    |
+| `max_rps`           | int \| null | null  | 最大请求速率 (requests per second), 为 `null` 则不限制 |
 | `headless`         | bool   | false         | 是否以无头模式启动浏览器                   |
 | `user_data_folder` | string | `""`          | 浏览器用户数据目录, 为空则使用默认目录      |
 | `profile_name`     | string | `""`          | 使用的浏览器配置名称, 为空则使用默认配置        |
@@ -21,7 +21,7 @@
 
 | 参数名               | 类型    | 默认值              | 说明                                   |
 |---------------------|--------|-------------------|--------------------------------------|
-| `request_interval`   | int    | 5                 | 同一本书各章节请求间隔 (秒)               |
+| `request_interval`   | float  | 5.0               | 同一本书各章节请求间隔 (秒)                   |
 | `raw_data_dir`       | string | `"./raw_data"`    | 原始章节 HTML/JSON 存放目录             |
 | `output_dir`         | string | `"./downloads"`   | 最终输出文件存放目录                   |
 | `cache_dir`          | string | `"./novel_cache"` | 本地缓存目录 (字体 / 图片等)       |
@@ -32,6 +32,21 @@
 | `debug.save_html`    | bool   | false             | 是否保存抓取到的原始 HTML 到磁盘         |
 | `debug.log_level`    | string | `"INFO"`          | 日志级别: DEBUG, INFO, WARNING, ERROR |
 
+#### general.font_ocr 配置
+
+| 参数名            | 类型         | 默认值     | 说明                                                   |
+|------------------|--------------|------------|--------------------------------------------------------|
+| `decode_font`     | bool         | false      | 是否尝试本地解码混淆字体                                |
+| `use_freq`        | bool         | false      | 是否使用频率分析辅助识别                                 |
+| `ocr_version`     | string       | `"v2.0"`   | OCR 使用的模型版本: `v1.0` / `v2.0`                      |
+| `use_ocr`         | bool         | true       | 是否启用 OCR 辅助识别                                   |
+| `use_vec`         | bool         | false      | 是否使用向量相似度辅助识别文本                            |
+| `save_font_debug` | bool         | false      | 是否保存字体调试数据                                     |
+| `batch_size`      | int          | 32         | OCR 批处理数量, 影响识别速度和内存使用                   |
+| `gpu_mem`         | int          | 500        | GPU 显存限制 (MB)                                       |
+| `gpu_id`          | int/null     | null       | 使用哪个 GPU, null 表示自动选择                         |
+| `ocr_weight`      | float        | 0.6        | 最终结果中 OCR 部分的权重                                |
+| `vec_weight`      | float        | 0.4        | 最终结果中向量识别部分的权重                             |
 
 ### sites 配置
 
@@ -39,19 +54,9 @@
 
 | 参数名           | 类型             | 默认值        | 说明                                                           |
 |------------------|------------------|---------------|----------------------------------------------------------------|
-| `book_ids`        | array[string]     | —             | 小说 ID 列表（如 `1010868264`）                                 |
-| `mode`            | string            | `"browser"`   | 请求方式：`browser` / `session` / `async`                       |
+| `book_ids`        | array[string]     | —             | 小说 ID 列表 (如 `1010868264`)                                 |
+| `mode`            | string            | `"browser"`   | 请求方式: `browser` / `session` / `async`                       |
 | `login_required`  | bool              | false         | 是否需要登录才能访问                                           |
-| `decode_font`     | bool              | false         | 是否尝试本地解码混淆字体                                        |
-| `use_freq`        | bool              | false         | 是否使用字符频率分析                                           |
-| `use_ocr`         | bool              | false         | 是否使用 OCR 辅助识别文本                                      |
-| `ocr_version`     | string            | `"v2.0"`      | OCR 使用的模型版本：`v1.0` / `v2.0`                             |
-| `use_vec`         | bool              | false         | 是否使用向量相似度辅助识别文本                                  |
-| `batch_size`      | int               | 32            | OCR 批处理数量，影响识别速度和内存消耗                         |
-| `ocr_weight`      | float             | 0.6           | 最终结果中 OCR 部分的权重 (与 `vec_weight` 搭配使用)           |
-| `vec_weight`      | float             | 0.4           | 最终结果中向量识别部分的权重 (与 `ocr_weight` 搭配使用)        |
-| `save_font_debug` | bool              | false         | 是否保存字体解码的调试数据（调试用）                           |
-
 
 ### output 配置
 

--- a/novel_downloader/config/adapter.py
+++ b/novel_downloader/config/adapter.py
@@ -93,18 +93,21 @@ class ConfigAdapter:
         config["sites"][site] 中读取解析器相关配置, 返回 ParserConfig 实例
         """
         gen = self._config.get("general", {})
+        font_ocr = gen.get("font_ocr", {})
         site_cfg = self._config.get("sites", {}).get(self._site, {})
         return ParserConfig(
             cache_dir=gen.get("cache_dir", "./cache"),
-            decode_font=site_cfg.get("decode_font", False),
-            use_freq=site_cfg.get("use_freq", False),
-            use_ocr=site_cfg.get("use_ocr", True),
-            use_vec=site_cfg.get("use_vec", False),
-            ocr_version=site_cfg.get("ocr_version", "v1.0"),
-            save_font_debug=site_cfg.get("save_font_debug", False),
-            batch_size=site_cfg.get("batch_size", 32),
-            ocr_weight=site_cfg.get("ocr_weight", 0.6),
-            vec_weight=site_cfg.get("vec_weight", 0.4),
+            decode_font=font_ocr.get("decode_font", False),
+            use_freq=font_ocr.get("use_freq", False),
+            use_ocr=font_ocr.get("use_ocr", True),
+            use_vec=font_ocr.get("use_vec", False),
+            ocr_version=font_ocr.get("ocr_version", "v1.0"),
+            save_font_debug=font_ocr.get("save_font_debug", False),
+            batch_size=font_ocr.get("batch_size", 32),
+            gpu_mem=font_ocr.get("gpu_mem", 500),
+            gpu_id=font_ocr.get("gpu_id", None),
+            ocr_weight=font_ocr.get("ocr_weight", 0.6),
+            vec_weight=font_ocr.get("vec_weight", 0.4),
             mode=site_cfg.get("mode", "session"),
         )
 

--- a/novel_downloader/config/models.py
+++ b/novel_downloader/config/models.py
@@ -24,10 +24,10 @@ from typing import Any, Dict, List, Literal, Optional, TypedDict
 # === Requesters ===
 @dataclass
 class RequesterConfig:
-    wait_time: int = 5
+    wait_time: float = 5.0
     retry_times: int = 3
-    retry_interval: int = 5
-    timeout: int = 30
+    retry_interval: float = 5.0
+    timeout: float = 30.0
     headless: bool = True
     user_data_folder: str = ""
     profile_name: str = ""
@@ -41,7 +41,7 @@ class RequesterConfig:
 # === Downloaders ===
 @dataclass
 class DownloaderConfig:
-    request_interval: int = 5
+    request_interval: float = 5.0
     raw_data_dir: str = "./raw_data"
     cache_dir: str = "./novel_cache"
     download_workers: int = 4

--- a/novel_downloader/config/models.py
+++ b/novel_downloader/config/models.py
@@ -63,6 +63,8 @@ class ParserConfig:
     use_vec: bool = False
     ocr_version: str = "v1.0"
     batch_size: int = 32
+    gpu_mem: int = 500
+    gpu_id: Optional[int] = None
     ocr_weight: float = 0.6
     vec_weight: float = 0.4
     save_font_debug: bool = False

--- a/novel_downloader/core/downloaders/base_async_downloader.py
+++ b/novel_downloader/core/downloaders/base_async_downloader.py
@@ -94,7 +94,7 @@ class BaseAsyncDownloader(AsyncDownloaderProtocol, abc.ABC):
         return self._config.login_required
 
     @property
-    def request_interval(self) -> int:
+    def request_interval(self) -> float:
         return self._config.request_interval
 
     async def prepare(self) -> None:

--- a/novel_downloader/core/interfaces/async_requester_protocol.py
+++ b/novel_downloader/core/interfaces/async_requester_protocol.py
@@ -28,7 +28,9 @@ class AsyncRequesterProtocol(Protocol):
         """
         ...
 
-    async def get_book_info(self, book_id: str, wait_time: Optional[int] = None) -> str:
+    async def get_book_info(
+        self, book_id: str, wait_time: Optional[float] = None
+    ) -> str:
         """
         Fetch the raw HTML (or JSON) of the book info page asynchronously.
 
@@ -39,7 +41,7 @@ class AsyncRequesterProtocol(Protocol):
         ...
 
     async def get_book_chapter(
-        self, book_id: str, chapter_id: str, wait_time: Optional[int] = None
+        self, book_id: str, chapter_id: str, wait_time: Optional[float] = None
     ) -> str:
         """
         Fetch the raw HTML (or JSON) of a single chapter asynchronously.
@@ -51,7 +53,7 @@ class AsyncRequesterProtocol(Protocol):
         """
         ...
 
-    async def get_bookcase(self, wait_time: Optional[int] = None) -> str:
+    async def get_bookcase(self, wait_time: Optional[float] = None) -> str:
         """
         Optional: Retrieve the HTML content of the authenticated
         user's bookcase page asynchronously.

--- a/novel_downloader/core/interfaces/requester_protocol.py
+++ b/novel_downloader/core/interfaces/requester_protocol.py
@@ -26,7 +26,7 @@ class RequesterProtocol(Protocol):
         """
         ...
 
-    def get_book_info(self, book_id: str, wait_time: Optional[int] = None) -> str:
+    def get_book_info(self, book_id: str, wait_time: Optional[float] = None) -> str:
         """
         Fetch the raw HTML (or JSON) of the book info page.
 
@@ -37,7 +37,7 @@ class RequesterProtocol(Protocol):
         ...
 
     def get_book_chapter(
-        self, book_id: str, chapter_id: str, wait_time: Optional[int] = None
+        self, book_id: str, chapter_id: str, wait_time: Optional[float] = None
     ) -> str:
         """
         Fetch the raw HTML (or JSON) of a single chapter.
@@ -55,7 +55,7 @@ class RequesterProtocol(Protocol):
         """
         ...
 
-    def get_bookcase(self, wait_time: Optional[int] = None) -> str:
+    def get_bookcase(self, wait_time: Optional[float] = None) -> str:
         """
         Optional: Retrieve the HTML content of the authenticated user's bookcase page.
 

--- a/novel_downloader/core/parsers/qidian_parser/browser/main_parser.py
+++ b/novel_downloader/core/parsers/qidian_parser/browser/main_parser.py
@@ -60,6 +60,8 @@ class QidianBrowserParser(BaseParser):
                 use_ocr=config.use_ocr,
                 use_vec=config.use_vec,
                 batch_size=config.batch_size,
+                gpu_mem=config.gpu_mem,
+                gpu_id=config.gpu_id,
                 ocr_weight=config.ocr_weight,
                 vec_weight=config.vec_weight,
                 font_debug=config.save_font_debug,

--- a/novel_downloader/core/parsers/qidian_parser/session/main_parser.py
+++ b/novel_downloader/core/parsers/qidian_parser/session/main_parser.py
@@ -63,6 +63,8 @@ class QidianSessionParser(BaseParser):
                 use_ocr=config.use_ocr,
                 use_vec=config.use_vec,
                 batch_size=config.batch_size,
+                gpu_mem=config.gpu_mem,
+                gpu_id=config.gpu_id,
                 ocr_weight=config.ocr_weight,
                 vec_weight=config.vec_weight,
                 font_debug=config.save_font_debug,

--- a/novel_downloader/core/requesters/base_async_session.py
+++ b/novel_downloader/core/requesters/base_async_session.py
@@ -51,7 +51,7 @@ class BaseAsyncSession(AsyncRequesterProtocol, abc.ABC):
 
     Attributes:
         _session (ClientSession): The persistent aiohttp client session.
-        _timeout (int): Timeout for each request in seconds.
+        _timeout (float): Timeout for each request in seconds.
         _retry_times (int): Number of retry attempts on failure.
         _retry_interval (float): Delay (in seconds) between retries.
         _headers (Dict[str, str]): Default HTTP headers to send.
@@ -111,7 +111,9 @@ class BaseAsyncSession(AsyncRequesterProtocol, abc.ABC):
         )
 
     @abc.abstractmethod
-    async def get_book_info(self, book_id: str, wait_time: Optional[int] = None) -> str:
+    async def get_book_info(
+        self, book_id: str, wait_time: Optional[float] = None
+    ) -> str:
         """
         Fetch the raw HTML (or JSON) of the book info page asynchronously.
 
@@ -123,7 +125,7 @@ class BaseAsyncSession(AsyncRequesterProtocol, abc.ABC):
 
     @abc.abstractmethod
     async def get_book_chapter(
-        self, book_id: str, chapter_id: str, wait_time: Optional[int] = None
+        self, book_id: str, chapter_id: str, wait_time: Optional[float] = None
     ) -> str:
         """
         Fetch the raw HTML (or JSON) of a single chapter asynchronously.
@@ -135,7 +137,7 @@ class BaseAsyncSession(AsyncRequesterProtocol, abc.ABC):
         """
         ...
 
-    async def get_bookcase(self, wait_time: Optional[int] = None) -> str:
+    async def get_bookcase(self, wait_time: Optional[float] = None) -> str:
         """
         Optional: Retrieve the HTML content of the authenticated user's bookcase page.
         Subclasses that support user login/bookcase should override this.
@@ -238,7 +240,7 @@ class BaseAsyncSession(AsyncRequesterProtocol, abc.ABC):
         return self._session
 
     @property
-    def timeout(self) -> int:
+    def timeout(self) -> float:
         """Return the default timeout setting."""
         return self._timeout
 

--- a/novel_downloader/core/requesters/base_browser.py
+++ b/novel_downloader/core/requesters/base_browser.py
@@ -111,7 +111,7 @@ class BaseBrowser(RequesterProtocol, abc.ABC):
         )
 
     @abc.abstractmethod
-    def get_book_info(self, book_id: str, wait_time: Optional[int] = None) -> str:
+    def get_book_info(self, book_id: str, wait_time: Optional[float] = None) -> str:
         """
         Fetch the raw HTML (or JSON) of the book info page.
 
@@ -123,7 +123,7 @@ class BaseBrowser(RequesterProtocol, abc.ABC):
 
     @abc.abstractmethod
     def get_book_chapter(
-        self, book_id: str, chapter_id: str, wait_time: Optional[int] = None
+        self, book_id: str, chapter_id: str, wait_time: Optional[float] = None
     ) -> str:
         """
         Fetch the raw HTML (or JSON) of a single chapter.
@@ -135,7 +135,7 @@ class BaseBrowser(RequesterProtocol, abc.ABC):
         """
         ...
 
-    def get_bookcase(self, wait_time: Optional[int] = None) -> str:
+    def get_bookcase(self, wait_time: Optional[float] = None) -> str:
         """
         Optional: Retrieve the HTML content of the authenticated user's bookcase page.
 

--- a/novel_downloader/core/requesters/base_session.py
+++ b/novel_downloader/core/requesters/base_session.py
@@ -28,7 +28,7 @@ class BaseSession(RequesterProtocol, abc.ABC):
 
     Attributes:
         _session (requests.Session): The persistent HTTP session.
-        _timeout (int): Timeout for each request in seconds.
+        _timeout (float): Timeout for each request in seconds.
     """
 
     def _init_session(
@@ -81,7 +81,7 @@ class BaseSession(RequesterProtocol, abc.ABC):
         )
 
     @abc.abstractmethod
-    def get_book_info(self, book_id: str, wait_time: Optional[int] = None) -> str:
+    def get_book_info(self, book_id: str, wait_time: Optional[float] = None) -> str:
         """
         Fetch the raw HTML (or JSON) of the book info page.
 
@@ -93,7 +93,7 @@ class BaseSession(RequesterProtocol, abc.ABC):
 
     @abc.abstractmethod
     def get_book_chapter(
-        self, book_id: str, chapter_id: str, wait_time: Optional[int] = None
+        self, book_id: str, chapter_id: str, wait_time: Optional[float] = None
     ) -> str:
         """
         Fetch the raw HTML (or JSON) of a single chapter.
@@ -105,7 +105,7 @@ class BaseSession(RequesterProtocol, abc.ABC):
         """
         ...
 
-    def get_bookcase(self, wait_time: Optional[int] = None) -> str:
+    def get_bookcase(self, wait_time: Optional[float] = None) -> str:
         """
         Optional: Retrieve the HTML content of the authenticated user's bookcase page.
 
@@ -171,7 +171,7 @@ class BaseSession(RequesterProtocol, abc.ABC):
         return self._session
 
     @property
-    def timeout(self) -> int:
+    def timeout(self) -> float:
         """Return the default timeout setting."""
         return self._timeout
 

--- a/novel_downloader/core/requesters/common_requester/common_async_session.py
+++ b/novel_downloader/core/requesters/common_requester/common_async_session.py
@@ -45,7 +45,9 @@ class CommonAsyncSession(BaseAsyncSession):
         self._site = site
         self._profile = profile
 
-    async def get_book_info(self, book_id: str, wait_time: Optional[int] = None) -> str:
+    async def get_book_info(
+        self, book_id: str, wait_time: Optional[float] = None
+    ) -> str:
         """
         Fetch the raw HTML of the book info page asynchronously.
 
@@ -62,7 +64,7 @@ class CommonAsyncSession(BaseAsyncSession):
         return html
 
     async def get_book_chapter(
-        self, book_id: str, chapter_id: str, wait_time: Optional[int] = None
+        self, book_id: str, chapter_id: str, wait_time: Optional[float] = None
     ) -> str:
         """
         Fetch the raw HTML of a single chapter asynchronously.

--- a/novel_downloader/core/requesters/common_requester/common_session.py
+++ b/novel_downloader/core/requesters/common_requester/common_session.py
@@ -47,7 +47,7 @@ class CommonSession(BaseSession):
         self._site = site
         self._profile = profile
 
-    def get_book_info(self, book_id: str, wait_time: Optional[int] = None) -> str:
+    def get_book_info(self, book_id: str, wait_time: Optional[float] = None) -> str:
         """
         Fetch the raw HTML (or JSON) of the book info page.
 
@@ -75,7 +75,7 @@ class CommonSession(BaseSession):
         raise RuntimeError("Unexpected error: get_book_info failed without returning")
 
     def get_book_chapter(
-        self, book_id: str, chapter_id: str, wait_time: Optional[int] = None
+        self, book_id: str, chapter_id: str, wait_time: Optional[float] = None
     ) -> str:
         """
         Fetch the raw HTML (or JSON) of a single chapter.

--- a/novel_downloader/core/requesters/qidian_requester/qidian_broswer.py
+++ b/novel_downloader/core/requesters/qidian_requester/qidian_broswer.py
@@ -266,7 +266,7 @@ class QidianBrowser(BaseBrowser):
         """
         return self.QIDIAN_BOOKCASE_URL
 
-    def get_book_info(self, book_id: str, wait_time: Optional[int] = None) -> str:
+    def get_book_info(self, book_id: str, wait_time: Optional[float] = None) -> str:
         """
         Retrieve the HTML of a Qidian book info page.
 
@@ -311,7 +311,7 @@ class QidianBrowser(BaseBrowser):
             time.sleep(pause)
 
     def get_book_chapter(
-        self, book_id: str, chapter_id: str, wait_time: Optional[int] = None
+        self, book_id: str, chapter_id: str, wait_time: Optional[float] = None
     ) -> str:
         """
         Retrieve the HTML content of a specific chapter.
@@ -347,7 +347,7 @@ class QidianBrowser(BaseBrowser):
             logger.warning("[fetch] Error fetching chapter from '%s': %s", url, e)
             return ""
 
-    def get_bookcase(self, wait_time: Optional[int] = None) -> str:
+    def get_bookcase(self, wait_time: Optional[float] = None) -> str:
         """
         Retrieve the HTML content of the logged‑in user's Qidian bookcase page.
 

--- a/novel_downloader/core/requesters/qidian_requester/qidian_session.py
+++ b/novel_downloader/core/requesters/qidian_requester/qidian_session.py
@@ -108,7 +108,7 @@ class QidianSession(BaseSession):
         self.get("https://www.qidian.com")
         return True
 
-    def get_book_info(self, book_id: str, wait_time: Optional[int] = None) -> str:
+    def get_book_info(self, book_id: str, wait_time: Optional[float] = None) -> str:
         """
         Fetch the raw HTML of the book info page.
 
@@ -140,7 +140,7 @@ class QidianSession(BaseSession):
         raise RuntimeError("Unexpected fall-through in get_book_info")
 
     def get_book_chapter(
-        self, book_id: str, chapter_id: str, wait_time: Optional[int] = None
+        self, book_id: str, chapter_id: str, wait_time: Optional[float] = None
     ) -> str:
         """
         Fetch the HTML of a single chapter.
@@ -174,7 +174,7 @@ class QidianSession(BaseSession):
 
         raise RuntimeError("Unexpected fall-through in get_book_chapter")
 
-    def get_bookcase(self, wait_time: Optional[int] = None) -> str:
+    def get_bookcase(self, wait_time: Optional[float] = None) -> str:
         """
         Retrieve the user's *bookcase* page.
 

--- a/novel_downloader/resources/config/settings.yaml
+++ b/novel_downloader/resources/config/settings.yaml
@@ -1,9 +1,9 @@
 # 网络请求层设置
 requests:
-  wait_time: 5                      # 每次请求等待时间 (秒)
+  wait_time: 5.0                    # 每次请求等待时间 (秒)
   retry_times: 3                    # 请求失败重试次数
-  retry_interval: 5
-  timeout: 30                       # 页面加载超时时间 (秒)
+  retry_interval: 5.0
+  timeout: 30.0                     # 页面加载超时时间 (秒)
   max_rps: null                     # 最大请求速率 (requests per second), 为 null 则不限制
   # DrissionPage 专用设置
   headless: false                   # 是否以无头模式启动浏览器
@@ -15,7 +15,7 @@ requests:
 
 # 全局通用设置
 general:
-  request_interval: 5               # 同一本书各章节请求间隔 (秒)
+  request_interval: 5.0             # 同一本书各章节请求间隔 (秒)
   raw_data_dir: "./raw_data"        # 原始章节 HTML/JSON 存放目录
   output_dir: "./downloads"         # 最终输出文件存放目录
   cache_dir: "./novel_cache"        # 本地缓存目录 (字体 / 图片等)

--- a/novel_downloader/resources/config/settings.yaml
+++ b/novel_downloader/resources/config/settings.yaml
@@ -26,6 +26,18 @@ general:
   debug:
     save_html: false                # 是否将抓取到的原始 HTML 保留到磁盘
     log_level: "INFO"               # 日志级别: DEBUG, INFO, WARNING, ERROR
+  font_ocr:
+    decode_font: false              # 是否尝试本地解码混淆字体
+    use_freq: false                 # 是否使用频率分析
+    ocr_version: "v2.0"             # "v1.0" / "v2.0"
+    use_ocr: true                   # 是否使用 OCR 辅助识别文本
+    use_vec: false                  # 是否使用 Vector 辅助识别文本
+    save_font_debug: false          # 是否保存字体解码调试数据
+    batch_size: 32
+    gpu_mem: 500                    # GPU 显存限制 (MB)
+    gpu_id: null                    # 使用哪个 GPU
+    ocr_weight: 0.6
+    vec_weight: 0.4
 
 # 各站点的特定配置
 sites:
@@ -38,15 +50,6 @@ sites:
       - "0000000000"
     mode: "browser"                 # browser / session
     login_required: true            # 是否需要登录才能访问
-    decode_font: false              # 是否尝试本地解码混淆字体
-    use_freq: false                 # 是否使用频率分析
-    ocr_version: "v2.0"             # "v1.0" / "v2.0"
-    use_ocr: true                   # 是否使用 OCR 辅助识别文本
-    use_vec: false                  # 是否使用 Vector 辅助识别文本
-    save_font_debug: false          # 是否保存字体解码调试数据
-    batch_size: 32
-    ocr_weight: 0.6
-    vec_weight: 0.4
     #
   sample_site:
     book_ids:

--- a/novel_downloader/utils/fontocr/ocr_v2.py
+++ b/novel_downloader/utils/fontocr/ocr_v2.py
@@ -221,6 +221,8 @@ class FontOCRV2:
         use_ocr: bool = True,
         use_vec: bool = False,
         batch_size: int = 32,
+        gpu_mem: int = 500,
+        gpu_id: Optional[int] = None,
         ocr_weight: float = 0.6,
         vec_weight: float = 0.4,
         ocr_version: str = "v1.0",
@@ -232,6 +234,8 @@ class FontOCRV2:
         self.use_ocr = use_ocr
         self.use_vec = use_vec
         self.batch_size = batch_size
+        self.gpu_mem = gpu_mem
+        self.gpu_id = gpu_id
         self.ocr_weight = ocr_weight
         self.vec_weight = vec_weight
         self.ocr_version = ocr_version
@@ -279,6 +283,8 @@ class FontOCRV2:
             rec_batch_num=self.batch_size,
             use_space_char=False,
             use_gpu=gpu_available,
+            gpu_mem=self.gpu_mem,
+            gpu_id=self.gpu_id,
         )
 
     def _load_char_freq_db(self) -> bool:

--- a/tests/config/test_adapter.py
+++ b/tests/config/test_adapter.py
@@ -138,8 +138,14 @@ def test_parser_config_defaults():
 
 def test_parser_config_combined():
     config = {
-        "general": {"cache_dir": "./tmp"},
-        "sites": {"qidian": {"decode_font": True, "save_font_debug": True}},
+        "general": {
+            "cache_dir": "./tmp",
+            "font_ocr": {
+                "decode_font": True,
+                "save_font_debug": True,
+            },
+        },
+        "sites": {"qidian": {"mode": "session"}},
     }
     adapter = ConfigAdapter(config, "qidian")
     cfg = adapter.get_parser_config()

--- a/tests/config/test_models.py
+++ b/tests/config/test_models.py
@@ -11,6 +11,7 @@ Test that all config dataclasses:
 """
 
 from dataclasses import fields, is_dataclass
+from typing import Optional
 
 import pytest
 
@@ -27,6 +28,7 @@ EXPECTED_FIELDS = {
         "retry_times": int,
         "retry_interval": float,
         "timeout": float,
+        "max_rps": Optional[float],
         "headless": bool,
         "user_data_folder": str,
         "profile_name": str,
@@ -55,6 +57,8 @@ EXPECTED_FIELDS = {
         "use_vec": bool,
         "ocr_version": str,
         "batch_size": int,
+        "gpu_mem": int,
+        "gpu_id": Optional[int],
         "ocr_weight": float,
         "vec_weight": float,
         "save_font_debug": bool,

--- a/tests/config/test_models.py
+++ b/tests/config/test_models.py
@@ -23,10 +23,10 @@ from novel_downloader.config.models import (
 
 EXPECTED_FIELDS = {
     RequesterConfig: {
-        "wait_time": int,
+        "wait_time": float,
         "retry_times": int,
-        "retry_interval": int,
-        "timeout": int,
+        "retry_interval": float,
+        "timeout": float,
         "headless": bool,
         "user_data_folder": str,
         "profile_name": str,
@@ -36,7 +36,7 @@ EXPECTED_FIELDS = {
         "mode": str,
     },
     DownloaderConfig: {
-        "request_interval": int,
+        "request_interval": float,
         "raw_data_dir": str,
         "cache_dir": str,
         "parser_workers": int,


### PR DESCRIPTION
### Changes

- Changed time-related config fields (e.g. `wait_time`, `retry_interval`, `timeout`, `request_interval`) from `int` to `float` for greater precision and flexibility.
- Moved font/OCR-related settings (`decode_font`, `use_ocr`, `save_font_debug`, etc.) from per-site config (`sites[site]`) to a centralized `general.font_ocr` section.
- Updated the parser config loader and related test cases to reflect these changes.

### Purpose

- Support finer-grained control over time intervals (e.g. 0.5 seconds).
- Improve maintainability and consistency by consolidating all font decoding and OCR settings in one place.

### Notes

- This refactor includes structural changes to the config format.
- Documentation and example config files should be updated accordingly.