### PR TITLE
refactor(login): extract login from requester into downloader

### DIFF
--- a/docs/1-installation.md
+++ b/docs/1-installation.md
@@ -102,17 +102,17 @@ paddlepaddle==3.0.0
 
 该模式使用 `asyncio + aiohttp` 进行并发网页抓取, 适合抓取大量章节时提高效率
 
-#### 自定义限速
+#### 自定义请求限速策略
 
-在 `settings.toml` 中, 可以通过以下两个字段精细控制请求速率
+可在 `settings.toml` 配置文件中, 通过以下字段灵活控制请求速率, 以平衡性能与目标站点的可承受负载
 
 ```toml
-request_interval = 0     # 默认为请求之间的最小间隔 (秒), 设置为 0 表示不强制等待
-max_rps = 10             # 最大请求速率 (requests per second), 为 空 则不限制
+request_interval = 0.0   # 默认为请求之间的最小间隔 (秒), 设置为 0 表示不强制等待
+max_rps = 4              # 最大请求速率 (requests per second), 如不设置则请注释掉本行
 ```
 
-* **`request_interval`**: 每次请求后的等待时间 (秒), 将其设为 `0` 可以让抓取更连续。
-* **`max_rps`**: 每秒最多发起的请求数; 如果设置为具体数字 (如 `10`), 则最多每秒发送 10 个请求, 留空或 `null` 则不做限速。
+* **`request_interval`**: 控制每次请求之间的最小等待时间 (秒), 设置为 `0` 可实现更高的并发性和连续性, 适用于对请求频率容忍度较高的站点。
+* **`max_rps`**: 限制全局请求速率, 单位为每秒请求数(requests per second)。例如: 设为 4 则最多每秒发送 4 个请求; 若不希望启用此限制, 请注释掉该字段 (以 `#` 开头) 或将其移除。
 
 #### 示例配置
 
@@ -123,7 +123,7 @@ retry_times = 3                    # 请求失败重试次数
 backoff_factor = 2.0
 timeout = 30.0                     # 页面加载超时时间 (秒)
 max_connections = 10               # 并发连接的最大数 (async)
-max_rps = 10                       # 最大请求速率 (requests per second)
+max_rps = 4                        # 最大请求速率 (requests per second)
 
 # 全局通用设置
 [general]
@@ -144,4 +144,8 @@ mode = "async"                     # async / session
 login_required = false             # 是否需要登录才能访问
 ```
 
-上述配置下, Downloader 在异步模式下不会在请求间强制等待, 但会保证整体速率不超过 10 rps。
+上述配置下, Downloader 采用异步模式, 每次请求之间不强制等待 (`request_interval = 0.0`), 但将整体请求速率控制在每秒最多 4 次 (`max_rps = 4`)。
+
+> 注意: 部分站点在面对高频的访问频率时 (例如每秒 10 次), 可能因负载压力而返回 `503 Service Temporarily Unavailable` 错误。
+>
+> 建议根据具体站点的响应情况, 适当调低请求速率参数, 或稍后重新运行程序继续执行 (工具支持断点续爬, 已完成的数据不会被重复抓取)。

--- a/docs/6-supported-sites.md
+++ b/docs/6-supported-sites.md
@@ -68,7 +68,7 @@ novel-cli download --site yamibo 1234
 
   `https://www.esjzone.cc/detail/1660702902.html` -> `1660702902`
 
-  **注意**: 未登录状态下, 许多小说页面将无法访问, 浏览器会自动重定向到「論壇」页面
+  **注意**: 若用户未登录账号, 部分小说页面可能无法访问。此时, 浏览器将自动重定向至「論壇」页面, 导致内容加载失败。
 
 * 百合会 (yamibo)
 
@@ -77,6 +77,8 @@ novel-cli download --site yamibo 1234
 * 哔哩轻小说 (linovelib)
 
   `https://www.linovelib.com/novel/1234.html` -> `1234`
+
+  **注意**: 若请求间隔过短, 可能触发平台限制机制, 导致账号/设备在一段时间内被封禁或限制访问。
 
 ### 注意事项
 

--- a/novel_downloader/cli/download.py
+++ b/novel_downloader/cli/download.py
@@ -101,7 +101,7 @@ def download_cli(ctx: Context, book_ids: list[str], site: str) -> None:
 
             for book_id in valid_book_ids:
                 click.echo(t("download_downloading", book_id=book_id, site=site))
-                await async_downloader.download_one(book_id)
+                await async_downloader.download(book_id)
 
             await async_requester.close()
 
@@ -121,7 +121,7 @@ def download_cli(ctx: Context, book_ids: list[str], site: str) -> None:
 
         for book_id in valid_book_ids:
             click.echo(t("download_downloading", book_id=book_id, site=site))
-            sync_downloader.download_one(book_id)
+            sync_downloader.download(book_id)
 
         sync_requester.close()
 

--- a/novel_downloader/config/adapter.py
+++ b/novel_downloader/config/adapter.py
@@ -92,8 +92,6 @@ class ConfigAdapter:
             disable_images=req.get("disable_images", True),
             mute_audio=req.get("mute_audio", True),
             mode=site_cfg.get("mode", "session"),
-            username=site_cfg.get("username", ""),
-            password=site_cfg.get("password", ""),
         )
 
     def get_downloader_config(self) -> DownloaderConfig:
@@ -117,6 +115,8 @@ class ConfigAdapter:
             mode=site_cfg.get("mode", "session"),
             storage_backend=gen.get("storage_backend", "json"),
             storage_batch_size=gen.get("storage_batch_size", 1),
+            username=site_cfg.get("username", ""),
+            password=site_cfg.get("password", ""),
         )
 
     def get_parser_config(self) -> ParserConfig:

--- a/novel_downloader/config/models.py
+++ b/novel_downloader/config/models.py
@@ -40,8 +40,6 @@ class RequesterConfig:
     mode: ModeType = "session"
     max_connections: int = 10
     max_rps: float | None = None  # Maximum requests per second
-    username: str = ""
-    password: str = ""
 
 
 # === Downloaders ===
@@ -59,6 +57,8 @@ class DownloaderConfig:
     mode: ModeType = "session"
     storage_backend: StorageBackend = "json"
     storage_batch_size: int = 1
+    username: str = ""
+    password: str = ""
 
 
 # === Parsers ===

--- a/novel_downloader/core/downloaders/base/base_async.py
+++ b/novel_downloader/core/downloaders/base/base_async.py
@@ -46,51 +46,88 @@ class BaseAsyncDownloader(AsyncDownloaderProtocol, abc.ABC):
         self._cache_dir = Path(config.cache_dir) / site
         self._raw_data_dir.mkdir(parents=True, exist_ok=True)
         self._cache_dir.mkdir(parents=True, exist_ok=True)
+        self._is_logged_in = False
 
         self.logger = logging.getLogger(f"{__name__}.{self.__class__.__name__}")
 
-    async def download(self, book_ids: list[str]) -> None:
+    async def download_many(self, book_ids: list[str]) -> None:
         """
-        The general batch download process:
-          1. Iterate over all book IDs
-          2. For each ID, call `download_one()`
+        Download multiple books with pre-download hook and error handling.
 
         :param book_ids: A list of book identifiers to download.
         """
-        await self.prepare()
-
-        # 2) batch download
-        for idx, book_id in enumerate(book_ids, start=1):
-            self.logger.debug(
-                "[%s] Starting download for %r (%s/%s)",
-                self.__class__.__name__,
-                book_id,
-                idx,
-                len(book_ids),
+        if not await self._ensure_ready():
+            self.logger.warning(
+                "[%s] login failed, skipping download of %s",
+                self._site,
+                book_ids,
             )
+            return
+
+        for book_id in book_ids:
             try:
-                await self.download_one(book_id)
+                await self._download_one(book_id)
             except Exception as e:
                 self._handle_download_exception(book_id, e)
 
-    @abc.abstractmethod
-    async def download_one(self, book_id: str) -> None:
-        """
-        The full download logic for a single book.
+        await self._finalize()
 
-        Subclasses must implement this method.
+    async def download(self, book_id: str) -> None:
+        """
+        Download a single book with pre-download hook and error handling.
 
         :param book_id: The identifier of the book to download.
         """
+        if not await self._ensure_ready():
+            self.logger.warning(
+                "[%s] login failed, skipping download of %s",
+                self._site,
+                book_id,
+            )
+            return
+
+        try:
+            await self._download_one(book_id)
+        except Exception as e:
+            self._handle_download_exception(book_id, e)
+
+        await self._finalize()
+
+    @abc.abstractmethod
+    async def _download_one(self, book_id: str) -> None:
+        """
+        Subclasses must implement this to define how to download a single book.
+        """
         ...
 
-    async def prepare(self) -> None:
+    async def _prepare(self) -> None:
         """
-        Optional hook called before downloading each book.
+        Optional hook called before downloading.
 
         Subclasses can override this method to perform pre-download setup.
         """
         return
+
+    async def _finalize(self) -> None:
+        """
+        Optional hook called after downloading is complete.
+
+        Subclasses can override this method to perform post-download tasks,
+        such as saving state or releasing resources.
+        """
+        return
+
+    async def _async_login(self) -> bool:
+        """
+        Optional hook called if login is required.
+        """
+        return True
+
+    async def _handle_login(self) -> bool:
+        """
+        Perform login using a dispatcher mapping based on requester type.
+        """
+        return await self._async_login()
 
     @property
     def requester(self) -> AsyncRequesterProtocol:
@@ -151,3 +188,16 @@ class BaseAsyncDownloader(AsyncDownloaderProtocol, abc.ABC):
             book_id,
             error,
         )
+
+    async def _ensure_ready(self) -> bool:
+        """
+        Run pre-download preparation and login logic once if needed.
+        """
+        await self._prepare()
+
+        if self.login_required and not self._is_logged_in:
+            success = await self._handle_login()
+            if not success:
+                return False
+            self._is_logged_in = True
+        return True

--- a/novel_downloader/core/downloaders/base/base_sync.py
+++ b/novel_downloader/core/downloaders/base/base_sync.py
@@ -49,6 +49,7 @@ class BaseDownloader(SyncDownloaderProtocol, abc.ABC):
         self._saver = saver
         self._config = config
         self._site = site
+        self._login_required = config.login_required
 
         self._raw_data_dir = Path(config.raw_data_dir) / site
         self._cache_dir = Path(config.cache_dir) / site
@@ -57,46 +58,102 @@ class BaseDownloader(SyncDownloaderProtocol, abc.ABC):
 
         self.logger = logging.getLogger(f"{__name__}.{self.__class__.__name__}")
 
-    def download(self, book_ids: list[str]) -> None:
+        self._login_dispatch = {
+            "browser": self._browser_login,
+            "session": self._session_login,
+        }
+
+        self._is_logged_in = False
+        if config.login_required:
+            self._is_logged_in = self._handle_login()
+
+    def download_many(self, book_ids: list[str]) -> None:
         """
-        The general batch download process:
-          1. Iterate over all book IDs
-          2. For each ID, call `download_one()`
+        Download multiple books with pre-download hook and error handling.
 
         :param book_ids: A list of book identifiers to download.
         """
-        self.prepare()
-
-        for idx, book_id in enumerate(book_ids, start=1):
-            self.logger.debug(
-                "[downloader] Starting download for book_id: %s (%s/%s)",
-                book_id,
-                idx,
-                len(book_ids),
+        self._prepare()
+        if self._login_required and not self._is_logged_in:
+            self.logger.warning(
+                "[%s] login failed, skipping download of %s",
+                self._site,
+                book_ids,
             )
+            return
+
+        for book_id in book_ids:
             try:
-                self.download_one(book_id)
+                self._download_one(book_id)
             except Exception as e:
                 self._handle_download_exception(book_id, e)
+        self._finalize()
 
-    @abc.abstractmethod
-    def download_one(self, book_id: str) -> None:
+    def download(self, book_id: str) -> None:
         """
-        The full download logic for a single book.
-
-        Subclasses must implement this method.
+        Download a single book with pre-download hook and error handling.
 
         :param book_id: The identifier of the book to download.
         """
-        ...
+        self._prepare()
+        if self._login_required and not self._is_logged_in:
+            self.logger.warning(
+                "[%s] login failed, skipping download of %s",
+                self._site,
+                book_id,
+            )
+            return
 
-    def prepare(self) -> None:
+        try:
+            self._download_one(book_id)
+        except Exception as e:
+            self._handle_download_exception(book_id, e)
+        self._finalize()
+
+    @abc.abstractmethod
+    def _download_one(self, book_id: str) -> None:
         """
-        Optional hook called before downloading each book.
+        Subclasses must implement the logic to download a single book.
+        """
+        pass
+
+    def _prepare(self) -> None:
+        """
+        Optional hook called before downloading.
 
         Subclasses can override this method to perform pre-download setup.
         """
         return
+
+    def _finalize(self) -> None:
+        """
+        Optional hook called after downloading is complete.
+
+        Subclasses can override this method to perform post-download tasks,
+        such as saving state or releasing resources.
+        """
+        return
+
+    def _session_login(self) -> bool:
+        """
+        Optional hook called if login is required.
+        """
+        return True
+
+    def _browser_login(self) -> bool:
+        """
+        Optional hook called if login is required.
+        """
+        return True
+
+    def _handle_login(self) -> bool:
+        """
+        Perform login using a dispatcher mapping based on requester type.
+        """
+        login_method = self._login_dispatch.get(self._requester.requester_type)
+        if login_method:
+            return login_method()
+        return False
 
     @property
     def requester(self) -> SyncRequesterProtocol:

--- a/novel_downloader/core/downloaders/esjzone/esjzone_async.py
+++ b/novel_downloader/core/downloaders/esjzone/esjzone_async.py
@@ -12,6 +12,8 @@ from novel_downloader.core.interfaces import (
     ParserProtocol,
     SaverProtocol,
 )
+from novel_downloader.utils.state import state_mgr
+from novel_downloader.utils.time_utils import async_sleep_with_random_delay
 
 
 class EsjzoneAsyncDownloader(CommonAsyncDownloader):
@@ -25,3 +27,53 @@ class EsjzoneAsyncDownloader(CommonAsyncDownloader):
         config: DownloaderConfig,
     ):
         super().__init__(requester, parser, saver, config, "esjzone")
+
+    async def _async_login(self) -> bool:
+        """
+        Restore cookies persisted by the session-based workflow.
+        """
+        print("session login async called")
+        self._is_logged_in = False
+        cookies: dict[str, str] = state_mgr.get_cookies(self._site)
+
+        try:
+            if await self._requester.login(cookies=cookies):
+                self._is_logged_in = True
+                return True
+        except Exception as e:
+            self.logger.warning("Cookie login failed for site %s: %s", self._site, e)
+
+        username = self.config.username
+        password = self.config.password
+        print(f"user = {username} ; pass = {password}")
+        if not (username and password):
+            self.logger.warning(
+                "Username or password not configured for site %s", self._site
+            )
+            return False
+
+        MAX_RETRIES = 3
+        wait_time = self.config.request_interval
+        for _ in range(MAX_RETRIES):
+            try:
+                if await self._requester.login(username=username, password=password):
+                    self._is_logged_in = True
+                    return True
+            except Exception:
+                pass
+
+            await async_sleep_with_random_delay(
+                wait_time,
+                mul_spread=1.1,
+                max_sleep=wait_time + 2,
+            )
+        self.logger.warning("All login attempts failed for site %s", self._site)
+        return False
+
+    async def _finalize(self) -> None:
+        """
+        Save cookies to the state manager before closing.
+        """
+        if self.login_required:
+            state_mgr.set_cookies(self._site, self._requester.cookies)
+        return

--- a/novel_downloader/core/downloaders/esjzone/esjzone_sync.py
+++ b/novel_downloader/core/downloaders/esjzone/esjzone_sync.py
@@ -12,6 +12,8 @@ from novel_downloader.core.interfaces import (
     SaverProtocol,
     SyncRequesterProtocol,
 )
+from novel_downloader.utils.state import state_mgr
+from novel_downloader.utils.time_utils import sleep_with_random_delay
 
 
 class EsjzoneDownloader(CommonDownloader):
@@ -25,3 +27,51 @@ class EsjzoneDownloader(CommonDownloader):
         config: DownloaderConfig,
     ):
         super().__init__(requester, parser, saver, config, "esjzone")
+
+    def _session_login(self) -> bool:
+        """
+        Restore cookies persisted by the session-based workflow.
+        """
+        self._is_logged_in = False
+        cookies: dict[str, str] = state_mgr.get_cookies(self._site)
+
+        try:
+            if self._requester.login(cookies=cookies):
+                self._is_logged_in = True
+                return True
+        except Exception as e:
+            self.logger.warning("Cookie login failed for site %s: %s", self._site, e)
+
+        username = self.config.username
+        password = self.config.password
+        if not (username and password):
+            self.logger.warning(
+                "Username or password not configured for site %s", self._site
+            )
+            return False
+
+        MAX_RETRIES = 3
+        wait_time = self.config.request_interval
+        for _ in range(MAX_RETRIES):
+            try:
+                if self._requester.login(username=username, password=password):
+                    self._is_logged_in = True
+                    return True
+            except Exception:
+                pass
+
+            sleep_with_random_delay(
+                wait_time,
+                mul_spread=1.1,
+                max_sleep=wait_time + 2,
+            )
+        self.logger.warning("All login attempts failed for site %s", self._site)
+        return False
+
+    def _finalize(self) -> None:
+        """
+        Save cookies to the state manager before closing.
+        """
+        if self._requester.requester_type == "session" and self._login_required:
+            state_mgr.set_cookies(self._site, self._requester.cookies)
+        return

--- a/novel_downloader/core/downloaders/sfacg/sfacg_async.py
+++ b/novel_downloader/core/downloaders/sfacg/sfacg_async.py
@@ -12,6 +12,9 @@ from novel_downloader.core.interfaces import (
     ParserProtocol,
     SaverProtocol,
 )
+from novel_downloader.utils.cookies import resolve_cookies
+from novel_downloader.utils.i18n import t
+from novel_downloader.utils.state import state_mgr
 
 
 class SfacgAsyncDownloader(CommonAsyncDownloader):
@@ -25,3 +28,43 @@ class SfacgAsyncDownloader(CommonAsyncDownloader):
         config: DownloaderConfig,
     ):
         super().__init__(requester, parser, saver, config, "sfacg")
+
+    async def _async_login(self) -> bool:
+        """
+        Restore cookies persisted by the session-based workflow.
+        """
+        self._is_logged_in = False
+        cookies: dict[str, str] = state_mgr.get_cookies(self._site)
+
+        try:
+            if await self._requester.login(cookies=cookies):
+                self._is_logged_in = True
+                return True
+        except Exception as e:
+            self.logger.warning("Cookie login failed for site %s: %s", self._site, e)
+
+        MAX_RETRIES = 3
+        print(t("session_login_prompt_intro"))
+        for attempt in range(1, MAX_RETRIES + 1):
+            cookie_str = input(
+                t(
+                    "session_login_prompt_paste_cookie",
+                    attempt=attempt,
+                    max_retries=MAX_RETRIES,
+                )
+            ).strip()
+            try:
+                cookies = resolve_cookies(cookie_str)
+                if await self._requester.login(cookies=cookies):
+                    return True
+            except (ValueError, TypeError):
+                print(t("session_login_prompt_invalid_cookie"))
+        return False
+
+    async def _finalize(self) -> None:
+        """
+        Save cookies to the state manager before closing.
+        """
+        if self.login_required:
+            state_mgr.set_cookies(self._site, self._requester.cookies)
+        return

--- a/novel_downloader/core/downloaders/sfacg/sfacg_sync.py
+++ b/novel_downloader/core/downloaders/sfacg/sfacg_sync.py
@@ -12,6 +12,9 @@ from novel_downloader.core.interfaces import (
     SaverProtocol,
     SyncRequesterProtocol,
 )
+from novel_downloader.utils.cookies import resolve_cookies
+from novel_downloader.utils.i18n import t
+from novel_downloader.utils.state import state_mgr
 
 
 class SfacgDownloader(CommonDownloader):
@@ -25,3 +28,43 @@ class SfacgDownloader(CommonDownloader):
         config: DownloaderConfig,
     ):
         super().__init__(requester, parser, saver, config, "sfacg")
+
+    def _session_login(self) -> bool:
+        """
+        Restore cookies persisted by the session-based workflow.
+        """
+        self._is_logged_in = False
+        cookies: dict[str, str] = state_mgr.get_cookies(self._site)
+
+        try:
+            if self._requester.login(cookies=cookies):
+                self._is_logged_in = True
+                return True
+        except Exception as e:
+            self.logger.warning("Cookie login failed for site %s: %s", self._site, e)
+
+        MAX_RETRIES = 3
+        print(t("session_login_prompt_intro"))
+        for attempt in range(1, MAX_RETRIES + 1):
+            cookie_str = input(
+                t(
+                    "session_login_prompt_paste_cookie",
+                    attempt=attempt,
+                    max_retries=MAX_RETRIES,
+                )
+            ).strip()
+            try:
+                cookies = resolve_cookies(cookie_str)
+                if self.requester.login(cookies=cookies):
+                    return True
+            except (ValueError, TypeError):
+                print(t("session_login_prompt_invalid_cookie"))
+        return False
+
+    def _finalize(self) -> None:
+        """
+        Save cookies to the state manager before closing.
+        """
+        if self._requester.requester_type == "session" and self._login_required:
+            state_mgr.set_cookies(self._site, self._requester.cookies)
+        return

--- a/novel_downloader/core/downloaders/yamibo/yamibo_async.py
+++ b/novel_downloader/core/downloaders/yamibo/yamibo_async.py
@@ -12,6 +12,8 @@ from novel_downloader.core.interfaces import (
     ParserProtocol,
     SaverProtocol,
 )
+from novel_downloader.utils.state import state_mgr
+from novel_downloader.utils.time_utils import async_sleep_with_random_delay
 
 
 class YamiboAsyncDownloader(CommonAsyncDownloader):
@@ -25,3 +27,51 @@ class YamiboAsyncDownloader(CommonAsyncDownloader):
         config: DownloaderConfig,
     ):
         super().__init__(requester, parser, saver, config, "yamibo")
+
+    async def _async_login(self) -> bool:
+        """
+        Restore cookies persisted by the session-based workflow.
+        """
+        self._is_logged_in = False
+        cookies: dict[str, str] = state_mgr.get_cookies(self._site)
+
+        try:
+            if await self._requester.login(cookies=cookies):
+                self._is_logged_in = True
+                return True
+        except Exception as e:
+            self.logger.warning("Cookie login failed for site %s: %s", self._site, e)
+
+        username = self.config.username
+        password = self.config.password
+        if not (username and password):
+            self.logger.warning(
+                "Username or password not configured for site %s", self._site
+            )
+            return False
+
+        MAX_RETRIES = 3
+        wait_time = self.config.request_interval
+        for _ in range(MAX_RETRIES):
+            try:
+                if await self._requester.login(username=username, password=password):
+                    self._is_logged_in = True
+                    return True
+            except Exception:
+                pass
+
+            await async_sleep_with_random_delay(
+                wait_time,
+                mul_spread=1.1,
+                max_sleep=wait_time + 2,
+            )
+        self.logger.warning("All login attempts failed for site %s", self._site)
+        return False
+
+    async def _finalize(self) -> None:
+        """
+        Save cookies to the state manager before closing.
+        """
+        if self.login_required:
+            state_mgr.set_cookies(self._site, self._requester.cookies)
+        return

--- a/novel_downloader/core/downloaders/yamibo/yamibo_sync.py
+++ b/novel_downloader/core/downloaders/yamibo/yamibo_sync.py
@@ -12,6 +12,8 @@ from novel_downloader.core.interfaces import (
     SaverProtocol,
     SyncRequesterProtocol,
 )
+from novel_downloader.utils.state import state_mgr
+from novel_downloader.utils.time_utils import sleep_with_random_delay
 
 
 class YamiboDownloader(CommonDownloader):
@@ -25,3 +27,51 @@ class YamiboDownloader(CommonDownloader):
         config: DownloaderConfig,
     ):
         super().__init__(requester, parser, saver, config, "yamibo")
+
+    def _session_login(self) -> bool:
+        """
+        Restore cookies persisted by the session-based workflow.
+        """
+        self._is_logged_in = False
+        cookies: dict[str, str] = state_mgr.get_cookies(self._site)
+
+        try:
+            if self._requester.login(cookies=cookies):
+                self._is_logged_in = True
+                return True
+        except Exception as e:
+            self.logger.warning("Cookie login failed for site %s: %s", self._site, e)
+
+        username = self.config.username
+        password = self.config.password
+        if not (username and password):
+            self.logger.warning(
+                "Username or password not configured for site %s", self._site
+            )
+            return False
+
+        MAX_RETRIES = 3
+        wait_time = self.config.request_interval
+        for _ in range(MAX_RETRIES):
+            try:
+                if self._requester.login(username=username, password=password):
+                    self._is_logged_in = True
+                    return True
+            except Exception:
+                pass
+
+            sleep_with_random_delay(
+                wait_time,
+                mul_spread=1.1,
+                max_sleep=wait_time + 2,
+            )
+        self.logger.warning("All login attempts failed for site %s", self._site)
+        return False
+
+    def _finalize(self) -> None:
+        """
+        Save cookies to the state manager before closing.
+        """
+        if self._requester.requester_type == "session" and self._login_required:
+            state_mgr.set_cookies(self._site, self._requester.cookies)
+        return

--- a/novel_downloader/core/interfaces/async_downloader.py
+++ b/novel_downloader/core/interfaces/async_downloader.py
@@ -19,7 +19,7 @@ class AsyncDownloaderProtocol(Protocol):
     as well as optional pre-download hooks.
     """
 
-    async def download(self, book_ids: list[str]) -> None:
+    async def download_many(self, book_ids: list[str]) -> None:
         """
         Batch download entry point.
 
@@ -27,7 +27,7 @@ class AsyncDownloaderProtocol(Protocol):
         """
         ...
 
-    async def download_one(self, book_id: str) -> None:
+    async def download(self, book_id: str) -> None:
         """
         Download logic for a single book.
 

--- a/novel_downloader/core/interfaces/async_requester.py
+++ b/novel_downloader/core/interfaces/async_requester.py
@@ -83,3 +83,16 @@ class AsyncRequesterProtocol(Protocol):
         Shutdown and clean up any resources (e.g., close aiohttp session).
         """
         ...
+
+    @property
+    def requester_type(self) -> str:
+        ...
+
+    @property
+    def cookies(self) -> dict[str, str]:
+        """
+        Get the current session cookies.
+
+        :return: A dict mapping cookie names to their values.
+        """
+        ...

--- a/novel_downloader/core/interfaces/async_requester.py
+++ b/novel_downloader/core/interfaces/async_requester.py
@@ -27,7 +27,8 @@ class AsyncRequesterProtocol(Protocol):
         self,
         username: str = "",
         password: str = "",
-        manual_login: bool = False,
+        cookies: dict[str, str] | None = None,
+        attempt: int = 1,
         **kwargs: Any,
     ) -> bool:
         """

--- a/novel_downloader/core/interfaces/sync_downloader.py
+++ b/novel_downloader/core/interfaces/sync_downloader.py
@@ -19,7 +19,7 @@ class SyncDownloaderProtocol(Protocol):
     as well as optional pre-download hooks.
     """
 
-    def download(self, book_ids: list[str]) -> None:
+    def download_many(self, book_ids: list[str]) -> None:
         """
         Batch download entry point.
 
@@ -27,7 +27,7 @@ class SyncDownloaderProtocol(Protocol):
         """
         ...
 
-    def download_one(self, book_id: str) -> None:
+    def download(self, book_id: str) -> None:
         """
         Download logic for a single book.
 

--- a/novel_downloader/core/interfaces/sync_requester.py
+++ b/novel_downloader/core/interfaces/sync_requester.py
@@ -26,7 +26,8 @@ class SyncRequesterProtocol(Protocol):
         self,
         username: str = "",
         password: str = "",
-        manual_login: bool = False,
+        cookies: dict[str, str] | None = None,
+        attempt: int = 1,
         **kwargs: Any,
     ) -> bool:
         """

--- a/novel_downloader/core/interfaces/sync_requester.py
+++ b/novel_downloader/core/interfaces/sync_requester.py
@@ -81,3 +81,16 @@ class SyncRequesterProtocol(Protocol):
         Shutdown and cleans up resources.
         """
         ...
+
+    @property
+    def requester_type(self) -> str:
+        ...
+
+    @property
+    def cookies(self) -> dict[str, str]:
+        """
+        Get the current session cookies.
+
+        :return: A dict mapping cookie names to their values.
+        """
+        ...

--- a/novel_downloader/core/parsers/biquge/main_parser.py
+++ b/novel_downloader/core/parsers/biquge/main_parser.py
@@ -8,8 +8,7 @@ novel_downloader.core.parsers.biquge.main_parser
 import re
 from typing import Any
 
-from lxml import etree
-from lxml.etree import _Element
+from lxml import html
 
 from novel_downloader.core.parsers.base import BaseParser
 from novel_downloader.utils.chapter_storage import ChapterDict
@@ -31,10 +30,10 @@ class BiqugeParser(BaseParser):
         """
         if not html_str:
             return {}
-        tree = etree.HTML(html_str[0])
+        tree = html.fromstring(html_str[0])
         result: dict[str, Any] = {}
 
-        def extract_text(elem: _Element | None) -> str:
+        def extract_text(elem: html.HtmlElement | None) -> str:
             if elem is None:
                 return ""
             return "".join(elem.itertext(tag=None)).strip()
@@ -79,7 +78,7 @@ class BiqugeParser(BaseParser):
                 text = "".join(elem.itertext()).strip()
                 in_main_volume = "正文" in text
             elif in_main_volume and elem.tag == "dd":
-                a: list[_Element] = elem.xpath("./a")
+                a: list[html.HtmlElement] = elem.xpath("./a")
                 if a:
                     title = "".join(a[0].itertext(tag=None)).strip()
                     url = a[0].get("href", "").strip()
@@ -109,7 +108,7 @@ class BiqugeParser(BaseParser):
         """
         if not html_str:
             return None
-        tree = etree.HTML(html_str[0], parser=None)
+        tree = html.fromstring(html_str[0], parser=None)
 
         # 提取标题
         title_elem = tree.xpath('//div[@class="bookname"]/h1')

--- a/novel_downloader/core/parsers/esjzone/main_parser.py
+++ b/novel_downloader/core/parsers/esjzone/main_parser.py
@@ -7,8 +7,7 @@ novel_downloader.core.parsers.esjzone.main_parser
 
 from typing import Any
 
-from lxml import etree
-from lxml.etree import _Element
+from lxml import html
 
 from novel_downloader.core.parsers.base import BaseParser
 from novel_downloader.utils.chapter_storage import ChapterDict
@@ -54,7 +53,7 @@ class EsjzoneParser(BaseParser):
         """
         if not html_str or self._is_forum_page(html_str):
             return {}
-        tree = etree.HTML(html_str[0])
+        tree = html.fromstring(html_str[0])
         result: dict[str, Any] = {}
 
         result["book_name"] = self._get_text(tree, self._BOOK_NAME_XPATH)
@@ -147,7 +146,7 @@ class EsjzoneParser(BaseParser):
         """
         if not html_str or self._is_forum_page(html_str):
             return None
-        tree = etree.HTML(html_str[0], parser=None)
+        tree = html.fromstring(html_str[0], parser=None)
 
         content_lines: list[str] = []
         content_nodes = tree.xpath(self._CHAPTER_CONTENT_NODES_XPATH)
@@ -198,7 +197,7 @@ class EsjzoneParser(BaseParser):
         if not html_str:
             return False
 
-        tree = etree.HTML(html_str[0])
+        tree = html.fromstring(html_str[0])
         page_title = tree.xpath('string(//div[@class="page-title"]//h1)').strip()
         if page_title != "論壇":
             return False
@@ -208,7 +207,7 @@ class EsjzoneParser(BaseParser):
 
     @staticmethod
     def _get_text(
-        tree: _Element,
+        tree: html.HtmlElement,
         xpath: str,
         join: bool = False,
         clean_comma: bool = False,

--- a/novel_downloader/core/parsers/linovelib/main_parser.py
+++ b/novel_downloader/core/parsers/linovelib/main_parser.py
@@ -10,7 +10,7 @@ from itertools import islice
 from pathlib import PurePosixPath
 from typing import Any
 
-from lxml import etree
+from lxml import html
 
 from novel_downloader.core.parsers.base import BaseParser
 from novel_downloader.utils.chapter_storage import ChapterDict
@@ -55,7 +55,7 @@ class LinovelibParser(BaseParser):
         """
         if not html_str:
             return {}
-        info_tree = etree.HTML(html_str[0])
+        info_tree = html.fromstring(html_str[0])
         result: dict[str, Any] = {}
 
         result["book_name"] = self._safe_xpath(info_tree, self._BOOK_NAME_XPATH)
@@ -74,7 +74,7 @@ class LinovelibParser(BaseParser):
         vol_pages = html_str[1:]
         volumes: list[dict[str, Any]] = []
         for vol_page in vol_pages:
-            vol_tree = etree.HTML(vol_page)
+            vol_tree = html.fromstring(vol_page)
             volume_cover = self._safe_xpath(vol_tree, self._COVER_URL_XPATH)
             volume_name = self._safe_xpath(vol_tree, self._BOOK_NAME_XPATH)
             update_time = self._safe_xpath(
@@ -126,9 +126,9 @@ class LinovelibParser(BaseParser):
             return None
         title_text: str = ""
         contents: list[str] = []
-        for html in html_str:
-            is_encrypted = self._is_encrypted(html)
-            tree = etree.HTML(html)
+        for curr_html in html_str:
+            is_encrypted = self._is_encrypted(curr_html)
+            tree = html.fromstring(curr_html)
 
             if not title_text:
                 titles = tree.xpath(self._CHAPTER_TITLE_XPATH)
@@ -171,7 +171,7 @@ class LinovelibParser(BaseParser):
 
     def _safe_xpath(
         self,
-        tree: etree._Element,
+        tree: html.HtmlElement,
         path: str,
         replace: tuple[str, str] | None = None,
     ) -> str:
@@ -185,7 +185,7 @@ class LinovelibParser(BaseParser):
         return value
 
     @staticmethod
-    def _extract_intro(tree: etree._Element, xpath: str) -> str:
+    def _extract_intro(tree: html.HtmlElement, xpath: str) -> str:
         paragraphs = tree.xpath(xpath.replace("//text()", ""))
         lines = []
         for p in paragraphs:

--- a/novel_downloader/core/parsers/qidian/session/node_decryptor.py
+++ b/novel_downloader/core/parsers/qidian/session/node_decryptor.py
@@ -73,10 +73,6 @@ class QidianNodeDecryptor:
             try:
                 resource = QD_DECRYPT_SCRIPT_PATH
                 shutil.copyfile(str(resource), str(self.QIDIAN_DECRYPT_SCRIPT_PATH))
-                logger.info(
-                    "[decryptor] Copied decrypt script to %s",
-                    self.QIDIAN_DECRYPT_SCRIPT_PATH,
-                )
             except Exception as e:
                 logger.error("[decryptor] Failed to copy decrypt script: %s", e)
                 raise
@@ -90,9 +86,6 @@ class QidianNodeDecryptor:
                     self.QIDIAN_FOCK_JS_URL,
                     self.script_dir,
                     on_exist="overwrite",
-                )
-                logger.info(
-                    "[decryptor] Downloaded Fock module to %s", self.QIDIAN_FOCK_JS_PATH
                 )
             except Exception as e:
                 logger.error("[decryptor] Failed to download Fock JS module: %s", e)
@@ -133,13 +126,6 @@ class QidianNodeDecryptor:
             input_path.write_text(
                 json.dumps([cipher_str, chapter_str, fkp, fuid]),
                 encoding="utf-8",
-            )
-
-            logger.debug(
-                "[decryptor] Invoking Node.js: node %s %s %s",
-                self.script_path.name,
-                input_path.name,
-                output_path.name,
             )
 
             proc = subprocess.run(

--- a/novel_downloader/core/parsers/sfacg/main_parser.py
+++ b/novel_downloader/core/parsers/sfacg/main_parser.py
@@ -7,7 +7,7 @@ novel_downloader.core.parsers.sfacg.main_parser
 
 from typing import Any
 
-from lxml import etree
+from lxml import html
 
 from novel_downloader.core.parsers.base import BaseParser
 from novel_downloader.utils.chapter_storage import ChapterDict
@@ -52,8 +52,8 @@ class SfacgParser(BaseParser):
         if len(html_str) < 2:
             return {}
 
-        info_tree = etree.HTML(html_str[0])
-        catalog_tree = etree.HTML(html_str[1])
+        info_tree = html.fromstring(html_str[0])
+        catalog_tree = html.fromstring(html_str[1])
 
         result: dict[str, Any] = {}
 
@@ -131,7 +131,7 @@ class SfacgParser(BaseParser):
         ]
         if any(kw in html_str[0] for kw in keywords):
             return None
-        tree = etree.HTML(html_str[0])
+        tree = html.fromstring(html_str[0])
 
         content_lines: list[str] = []
         content_nodes = tree.xpath(self._CHAPTER_CONTENT_NODES_XPATH)

--- a/novel_downloader/core/parsers/yamibo/main_parser.py
+++ b/novel_downloader/core/parsers/yamibo/main_parser.py
@@ -7,7 +7,7 @@ novel_downloader.core.parsers.yamibo.main_parser
 
 from typing import Any
 
-from lxml import etree
+from lxml import html
 
 from novel_downloader.core.parsers.base import BaseParser
 from novel_downloader.utils.chapter_storage import ChapterDict
@@ -61,7 +61,7 @@ class YamiboParser(BaseParser):
         if not html_str:
             return {}
 
-        tree = etree.HTML(html_str[0])
+        tree = html.fromstring(html_str[0])
         result: dict[str, Any] = {}
 
         result["book_name"] = tree.xpath(self._BOOK_NAME_XPATH).strip()
@@ -164,7 +164,7 @@ class YamiboParser(BaseParser):
         """
         if not html_str:
             return None
-        tree = etree.HTML(html_str[0])
+        tree = html.fromstring(html_str[0])
 
         content_lines = tree.xpath(self._CHAPTER_CONTENT_XPATH)
         content = "\n\n".join(line.strip() for line in content_lines if line.strip())

--- a/novel_downloader/core/requesters/base/async_session.py
+++ b/novel_downloader/core/requesters/base/async_session.py
@@ -114,7 +114,8 @@ class BaseAsyncSession(AsyncRequesterProtocol, abc.ABC):
         self,
         username: str = "",
         password: str = "",
-        manual_login: bool = False,
+        cookies: dict[str, str] | None = None,
+        attempt: int = 1,
         **kwargs: Any,
     ) -> bool:
         """

--- a/novel_downloader/core/requesters/base/browser.py
+++ b/novel_downloader/core/requesters/base/browser.py
@@ -285,6 +285,21 @@ class BaseBrowser(SyncRequesterProtocol, abc.ABC):
             raise RuntimeError("Browser is not initialized or has been shut down.")
         return self._browser
 
+    @property
+    def cookies(self) -> dict[str, str]:
+        """
+        Get the current session cookies.
+
+        :return: A dict mapping cookie names to their values.
+        """
+        if self._page is None:
+            return {}
+        return cast(dict[str, str], self._page.cookies().as_dict())
+
+    @property
+    def requester_type(self) -> str:
+        return "browser"
+
     @staticmethod
     def _is_valid(value: str) -> bool:
         return bool(value and value.strip())

--- a/novel_downloader/core/requesters/base/browser.py
+++ b/novel_downloader/core/requesters/base/browser.py
@@ -61,6 +61,7 @@ class BaseBrowser(SyncRequesterProtocol, abc.ABC):
         self._browser: Chromium | None = None
         self._page: MixTab | None = None
         self._headless: bool = config.headless
+        self._headless_orig: bool = config.headless
 
         user_data_path = (
             config.user_data_folder
@@ -111,7 +112,8 @@ class BaseBrowser(SyncRequesterProtocol, abc.ABC):
         self,
         username: str = "",
         password: str = "",
-        manual_login: bool = False,
+        cookies: dict[str, str] | None = None,
+        attempt: int = 1,
         **kwargs: Any,
     ) -> bool:
         """

--- a/novel_downloader/core/requesters/base/session.py
+++ b/novel_downloader/core/requesters/base/session.py
@@ -84,7 +84,8 @@ class BaseSession(SyncRequesterProtocol, abc.ABC):
         self,
         username: str = "",
         password: str = "",
-        manual_login: bool = False,
+        cookies: dict[str, str] | None = None,
+        attempt: int = 1,
         **kwargs: Any,
     ) -> bool:
         """

--- a/novel_downloader/core/requesters/base/session.py
+++ b/novel_downloader/core/requesters/base/session.py
@@ -247,6 +247,10 @@ class BaseSession(SyncRequesterProtocol, abc.ABC):
             return dict(self._session.headers)
         return self._headers.copy()
 
+    @property
+    def requester_type(self) -> str:
+        return "session"
+
     def get_header(self, key: str, default: Any = None) -> Any:
         """
         Retrieve a specific header value by name.

--- a/novel_downloader/core/requesters/esjzone/async_session.py
+++ b/novel_downloader/core/requesters/esjzone/async_session.py
@@ -10,7 +10,6 @@ from typing import Any
 
 from novel_downloader.config.models import RequesterConfig
 from novel_downloader.core.requesters.base import BaseAsyncSession
-from novel_downloader.utils.state import state_mgr
 from novel_downloader.utils.time_utils import async_sleep_with_random_delay
 
 
@@ -207,9 +206,3 @@ class EsjzoneAsyncSession(BaseAsyncSession):
     def _extract_token(self, text: str) -> str:
         match = re.search(r"<JinJing>(.+?)</JinJing>", text)
         return match.group(1) if match else ""
-
-    async def _on_close(self) -> None:
-        """
-        Save cookies to the state manager before closing.
-        """
-        state_mgr.set_cookies("esjzone", self.cookies)

--- a/novel_downloader/core/requesters/esjzone/async_session.py
+++ b/novel_downloader/core/requesters/esjzone/async_session.py
@@ -10,7 +10,6 @@ from typing import Any
 
 from novel_downloader.config.models import RequesterConfig
 from novel_downloader.core.requesters.base import BaseAsyncSession
-from novel_downloader.utils.i18n import t
 from novel_downloader.utils.state import state_mgr
 from novel_downloader.utils.time_utils import async_sleep_with_random_delay
 
@@ -35,40 +34,45 @@ class EsjzoneAsyncSession(BaseAsyncSession):
         super().__init__(config)
         self._logged_in: bool = False
         self._request_interval = config.backoff_factor
-        self._retry_times = config.retry_times
-        self._username = config.username
-        self._password = config.password
 
     async def login(
         self,
         username: str = "",
         password: str = "",
-        manual_login: bool = False,
+        cookies: dict[str, str] | None = None,
+        attempt: int = 1,
         **kwargs: Any,
     ) -> bool:
         """
         Restore cookies persisted by the session-based workflow.
         """
-        cookies: dict[str, str] = state_mgr.get_cookies("esjzone")
-        username = username or self._username
-        password = password or self._password
+        if cookies:
+            self.update_cookies(cookies)
 
-        self.update_cookies(cookies)
-        for _ in range(self._retry_times):
-            if await self._check_login_status():
-                self.logger.debug("[auth] Already logged in.")
+        if await self._check_login_status():
+            self._logged_in = True
+            self.logger.debug("[auth] Logged in via cookies.")
+            return True
+
+        if not (username and password):
+            self.logger.warning("[auth] No credentials provided.")
+            return False
+
+        for _ in range(attempt):
+            if (
+                await self._api_login(username, password)
+                and await self._check_login_status()
+            ):
                 self._logged_in = True
                 return True
-            if username and password and not await self._api_login(username, password):
-                print(t("session_login_failed", site="esjzone"))
             await async_sleep_with_random_delay(
                 self._request_interval,
                 mul_spread=1.1,
                 max_sleep=self._request_interval + 2,
             )
 
-        self._logged_in = await self._check_login_status()
-        return self._logged_in
+        self._logged_in = False
+        return False
 
     async def get_book_info(
         self,

--- a/novel_downloader/core/requesters/esjzone/session.py
+++ b/novel_downloader/core/requesters/esjzone/session.py
@@ -9,7 +9,6 @@ from typing import Any
 
 from novel_downloader.config.models import RequesterConfig
 from novel_downloader.core.requesters.base import BaseSession
-from novel_downloader.utils.state import state_mgr
 from novel_downloader.utils.time_utils import sleep_with_random_delay
 
 
@@ -230,9 +229,3 @@ class EsjzoneSession(BaseSession):
     def _extract_token(self, text: str) -> str:
         match = re.search(r"<JinJing>(.+?)</JinJing>", text)
         return match.group(1) if match else ""
-
-    def _on_close(self) -> None:
-        """
-        Save cookies to the state manager before closing.
-        """
-        state_mgr.set_cookies("esjzone", self.cookies)

--- a/novel_downloader/core/requesters/qidian/broswer.py
+++ b/novel_downloader/core/requesters/qidian/broswer.py
@@ -195,6 +195,7 @@ class QidianBrowser(BaseBrowser):
                 self._options.no_imgs(False)
             if self._headless_orig or self._disable_images_orig:
                 self.restart_browser(headless=False)
+            self.page.get("https://www.qidian.com/")
             return True
 
         # restore

--- a/novel_downloader/core/requesters/qidian/broswer.py
+++ b/novel_downloader/core/requesters/qidian/broswer.py
@@ -14,7 +14,6 @@ from typing import Any
 
 from novel_downloader.config.models import RequesterConfig
 from novel_downloader.core.requesters.base import BaseBrowser
-from novel_downloader.utils.i18n import t
 
 
 class QidianBrowser(BaseBrowser):
@@ -48,16 +47,29 @@ class QidianBrowser(BaseBrowser):
         self,
         username: str = "",
         password: str = "",
-        manual_login: bool = False,
+        cookies: dict[str, str] | None = None,
+        attempt: int = 1,
         **kwargs: Any,
     ) -> bool:
         """
-        Attempt to log in to Qidian
+        Attempt to log in to Qidian via auto interaction.
+
+        :param attempt: Number of login attempts.
+        :param retry_interval: Seconds to wait between retries.
+        :return: True if login succeeded, False otherwise.
         """
-        if manual_login:
-            return self._login_manual()
-        else:
-            return self._login_auto()
+        for i in range(attempt):
+            if self._login_auto():
+                self._logged_in = True
+                return True
+
+            self.logger.debug("[auth] Login attempt %d failed, retrying...", i + 1)
+            if i < attempt - 1:
+                time.sleep(self._retry_interval)
+
+        self._logged_in = False
+        self.logger.warning("[auth] Login failed after %d attempts.", attempt)
+        return False
 
     def get_book_info(
         self,
@@ -168,11 +180,42 @@ class QidianBrowser(BaseBrowser):
         """
         return cls.BOOKCASE_URL
 
+    def set_interactive_mode(self, enable: bool) -> bool:
+        """
+        Enable or disable interactive browser mode for manual login.
+
+        When enabled, restarts browser in headful mode with images.
+        When disabled, restores browser to original state and checks login.
+
+        :param enable: True to enable, False to disable interactive mode.
+        :return: True if operation or login check succeeded, False otherwise.
+        """
+        if enable:
+            if self._disable_images_orig:
+                self._options.no_imgs(False)
+            if self._headless_orig or self._disable_images_orig:
+                self.restart_browser(headless=False)
+            return True
+
+        # restore
+        if self._disable_images_orig or self._headless_orig:
+            self._options.no_imgs(self._disable_images_orig)
+            self.restart_browser(headless=self._headless_orig)
+
+            success = self._check_login_status()
+            self._logged_in = success
+
+            if success:
+                self._logged_in = self._login_auto()
+
+        return self._logged_in
+
     def _login_auto(self, timeout: float = 5.0) -> bool:
         """
-        Attempt to log in to Qidian by handling overlays and clicking the login button.
+        Attempt one automatic login interaction (click once and check).
 
-        :return: True if login succeeds or is already in place; False otherwise.
+        :param timeout: Seconds to wait for login box to appear.
+        :return: True if login successful or already logged in; False otherwise.
         """
         try:
             self.page.get("https://www.qidian.com/")
@@ -181,95 +224,14 @@ class QidianBrowser(BaseBrowser):
             self.logger.warning("[auth] Failed to load login box: %s", e)
             return False
 
-        for attempt in range(1, self._retry_times + 1):
-            if self._check_login_status():
-                self.logger.debug("[auth] Already logged in.")
-                break
-            self.logger.debug("[auth] Attempting login click (#%s).", attempt)
-            if self.click_button("@id=login-btn", timeout=timeout):
-                self.logger.debug("[auth] Login button clicked.")
-            else:
-                self.logger.debug("[auth] Login button not found.")
-            time.sleep(self._retry_interval)
+        if self._check_login_status():
+            self.logger.debug("[auth] Already logged in.")
+            return True
 
-        self._logged_in = self._check_login_status()
-        if self._logged_in:
-            self.logger.info("[auth] Login successful.")
-        else:
-            self.logger.warning("[auth] Login failed after max retries.")
+        self.logger.debug("[auth] Clicking login button once.")
+        self.click_button("@id=login-btn", timeout=timeout)
 
-        return self._logged_in
-
-    def _login_manual(self) -> bool:
-        """
-        Guide the user through an interactive manual login flow.
-
-        Steps:
-            1. If the browser is headless, shut it down and restart in headful mode.
-            2. Navigate to the Qidian homepage.
-            3. Prompt the user to complete login, retrying up to `max_retries` times.
-            4. Once logged in, restore original headless mode if needed.
-
-        :param max_retries: Number of times to check for login success.
-        :return: True if login was detected, False otherwise.
-        """
-        original_headless = self._headless
-
-        # 1. Switch to headful mode if needed
-        if self._disable_images_orig:
-            self.logger.debug("[auth] Temporarily enabling images for manual login.")
-            self._options.no_imgs(False)
-            self.restart_browser(headless=False)
-        elif original_headless:
-            self.restart_browser(headless=False)
-
-        # 2. Navigate to home page
-        try:
-            self.page.get("https://www.qidian.com/")
-        except Exception as e:
-            self.logger.warning(
-                "[auth] Failed to load homepage for manual login: %s", e
-            )
-            return False
-
-        # 3. Retry loop
-        for attempt in range(1, self._retry_times + 1):
-            if self._check_login_status():
-                self.logger.debug("[auth] Already logged in.")
-                self._logged_in = True
-                break
-            if attempt == 1:
-                print(t("login_prompt_intro"))
-            input(
-                t(
-                    "login_prompt_press_enter",
-                    attempt=attempt,
-                    max_retries=self._retry_times,
-                )
-            )
-        else:
-            self.logger.warning(
-                "[auth] Manual login failed after %d attempts.", self._retry_times
-            )
-            self._logged_in = False
-            return self._logged_in
-
-        # 4. Restore headless if changed, then re-establish session
-        if original_headless or self._disable_images_orig:
-            self.logger.debug("[auth] Restoring browser settings after manual login...")
-            self._options.no_imgs(self._disable_images_orig)
-            self.restart_browser(headless=original_headless)
-            self._logged_in = self._login_auto()
-            if self._logged_in:
-                self.logger.info(
-                    "[auth] Login session successfully carried over after restart."
-                )
-            else:
-                self.logger.warning(
-                    "[auth] Lost login session after restoring headless mode."
-                )
-
-        return self._logged_in
+        return self._check_login_status()
 
     def _check_login_status(self) -> bool:
         """

--- a/novel_downloader/core/requesters/qidian/session.py
+++ b/novel_downloader/core/requesters/qidian/session.py
@@ -140,6 +140,7 @@ class QidianSession(BaseSession):
         try:
             resp = self.get(url, **kwargs)
             resp.raise_for_status()
+            resp.encoding = "UTF-8"
             return [resp.text]
         except Exception as exc:
             self.logger.warning(
@@ -225,6 +226,7 @@ class QidianSession(BaseSession):
         keywords = [
             'var buid = "fffffffffffffffffff"',
             "C2WF946J0/probe.js",
+            "login-area-wrap",
         ]
         resp_text = self.get_bookcase()
         if not resp_text:

--- a/novel_downloader/core/requesters/sfacg/async_session.py
+++ b/novel_downloader/core/requesters/sfacg/async_session.py
@@ -11,7 +11,6 @@ from typing import Any
 
 from novel_downloader.config.models import RequesterConfig
 from novel_downloader.core.requesters.base import BaseAsyncSession
-from novel_downloader.utils.i18n import t
 from novel_downloader.utils.state import state_mgr
 
 
@@ -38,37 +37,17 @@ class SfacgAsyncSession(BaseAsyncSession):
         self,
         username: str = "",
         password: str = "",
-        manual_login: bool = False,
+        cookies: dict[str, str] | None = None,
+        attempt: int = 1,
         **kwargs: Any,
     ) -> bool:
         """
         Restore cookies persisted by the session-based workflow.
         """
-        cookies: dict[str, str] = state_mgr.get_cookies("sfacg")
+        if not cookies:
+            return False
 
         self.update_cookies(cookies)
-        for attempt in range(1, self._retry_times + 1):
-            if await self._check_login_status():
-                self.logger.debug("[auth] Already logged in.")
-                self._logged_in = True
-                return True
-
-            if attempt == 1:
-                print(t("session_login_prompt_intro"))
-            cookie_str = input(
-                t(
-                    "session_login_prompt_paste_cookie",
-                    attempt=attempt,
-                    max_retries=self._retry_times,
-                )
-            ).strip()
-
-            cookies = self._parse_cookie_input(cookie_str)
-            if not cookies:
-                print(t("session_login_prompt_invalid_cookie"))
-                continue
-
-            self.update_cookies(cookies)
         self._logged_in = await self._check_login_status()
         return self._logged_in
 

--- a/novel_downloader/core/requesters/sfacg/async_session.py
+++ b/novel_downloader/core/requesters/sfacg/async_session.py
@@ -11,7 +11,6 @@ from typing import Any
 
 from novel_downloader.config.models import RequesterConfig
 from novel_downloader.core.requesters.base import BaseAsyncSession
-from novel_downloader.utils.state import state_mgr
 
 
 class SfacgAsyncSession(BaseAsyncSession):
@@ -175,9 +174,3 @@ class SfacgAsyncSession(BaseAsyncSession):
             return {k: v.value for k, v in parsed.items()}
         except Exception:
             return {}
-
-    async def _on_close(self) -> None:
-        """
-        Save cookies to the state manager before closing.
-        """
-        state_mgr.set_cookies("sfacg", self.cookies)

--- a/novel_downloader/core/requesters/sfacg/session.py
+++ b/novel_downloader/core/requesters/sfacg/session.py
@@ -9,7 +9,6 @@ from typing import Any
 
 from novel_downloader.config.models import RequesterConfig
 from novel_downloader.core.requesters.base import BaseSession
-from novel_downloader.utils.state import state_mgr
 
 
 class SfacgSession(BaseSession):
@@ -212,9 +211,3 @@ class SfacgSession(BaseSession):
             return {k: v.value for k, v in parsed.items()}
         except Exception:
             return {}
-
-    def _on_close(self) -> None:
-        """
-        Save cookies to the state manager before closing.
-        """
-        state_mgr.set_cookies("sfacg", self.cookies)

--- a/novel_downloader/core/requesters/sfacg/session.py
+++ b/novel_downloader/core/requesters/sfacg/session.py
@@ -9,7 +9,6 @@ from typing import Any
 
 from novel_downloader.config.models import RequesterConfig
 from novel_downloader.core.requesters.base import BaseSession
-from novel_downloader.utils.i18n import t
 from novel_downloader.utils.state import state_mgr
 
 
@@ -30,43 +29,22 @@ class SfacgSession(BaseSession):
     ):
         super().__init__(config)
         self._logged_in: bool = False
-        self._retry_times = config.retry_times
 
     def login(
         self,
         username: str = "",
         password: str = "",
-        manual_login: bool = False,
+        cookies: dict[str, str] | None = None,
+        attempt: int = 1,
         **kwargs: Any,
     ) -> bool:
         """
         Restore cookies persisted by the session-based workflow.
         """
-        cookies: dict[str, str] = state_mgr.get_cookies("sfacg")
+        if not cookies:
+            return False
 
         self.update_cookies(cookies)
-        for attempt in range(1, self._retry_times + 1):
-            if self._check_login_status():
-                self.logger.debug("[auth] Already logged in.")
-                self._logged_in = True
-                return True
-
-            if attempt == 1:
-                print(t("session_login_prompt_intro"))
-            cookie_str = input(
-                t(
-                    "session_login_prompt_paste_cookie",
-                    attempt=attempt,
-                    max_retries=self._retry_times,
-                )
-            ).strip()
-
-            cookies = self._parse_cookie_input(cookie_str)
-            if not cookies:
-                print(t("session_login_prompt_invalid_cookie"))
-                continue
-
-            self.update_cookies(cookies)
         self._logged_in = self._check_login_status()
         return self._logged_in
 

--- a/novel_downloader/core/requesters/yamibo/async_session.py
+++ b/novel_downloader/core/requesters/yamibo/async_session.py
@@ -11,7 +11,6 @@ from lxml import etree
 
 from novel_downloader.config.models import RequesterConfig
 from novel_downloader.core.requesters.base import BaseAsyncSession
-from novel_downloader.utils.i18n import t
 from novel_downloader.utils.state import state_mgr
 from novel_downloader.utils.time_utils import async_sleep_with_random_delay
 
@@ -36,40 +35,45 @@ class YamiboAsyncSession(BaseAsyncSession):
         super().__init__(config)
         self._logged_in: bool = False
         self._request_interval = config.backoff_factor
-        self._retry_times = config.retry_times
-        self._username = config.username
-        self._password = config.password
 
     async def login(
         self,
         username: str = "",
         password: str = "",
-        manual_login: bool = False,
+        cookies: dict[str, str] | None = None,
+        attempt: int = 1,
         **kwargs: Any,
     ) -> bool:
         """
         Restore cookies persisted by the session-based workflow.
         """
-        cookies: dict[str, str] = state_mgr.get_cookies("yamibo")
-        username = username or self._username
-        password = password or self._password
+        if cookies:
+            self.update_cookies(cookies)
 
-        self.update_cookies(cookies)
-        for _ in range(self._retry_times):
-            if await self._check_login_status():
-                self.logger.debug("[auth] Already logged in.")
+        if await self._check_login_status():
+            self._logged_in = True
+            self.logger.debug("[auth] Logged in via cookies.")
+            return True
+
+        if not (username and password):
+            self.logger.warning("[auth] No credentials provided.")
+            return False
+
+        for _ in range(attempt):
+            if (
+                await self._api_login(username, password)
+                and await self._check_login_status()
+            ):
                 self._logged_in = True
                 return True
-            if username and password and not await self._api_login(username, password):
-                print(t("session_login_failed", site="esjzone"))
             await async_sleep_with_random_delay(
                 self._request_interval,
                 mul_spread=1.1,
                 max_sleep=self._request_interval + 2,
             )
 
-        self._logged_in = await self._check_login_status()
-        return self._logged_in
+        self._logged_in = False
+        return False
 
     async def get_book_info(
         self,

--- a/novel_downloader/core/requesters/yamibo/async_session.py
+++ b/novel_downloader/core/requesters/yamibo/async_session.py
@@ -7,11 +7,10 @@ novel_downloader.core.requesters.yamibo.async_session
 
 from typing import Any
 
-from lxml import etree
+from lxml import html
 
 from novel_downloader.config.models import RequesterConfig
 from novel_downloader.core.requesters.base import BaseAsyncSession
-from novel_downloader.utils.state import state_mgr
 from novel_downloader.utils.time_utils import async_sleep_with_random_delay
 
 
@@ -162,7 +161,7 @@ class YamiboAsyncSession(BaseAsyncSession):
             resp_1 = await self.get(self.LOGIN_URL)
             resp_1.raise_for_status()
             text_1 = await resp_1.text()
-            tree = etree.HTML(text_1)
+            tree = html.fromstring(text_1)
             csrf_value = tree.xpath('//input[@name="_csrf-frontend"]/@value')
             csrf_value = csrf_value[0] if csrf_value else ""
             if not csrf_value:
@@ -207,9 +206,3 @@ class YamiboAsyncSession(BaseAsyncSession):
         if not resp_text:
             return False
         return not any(kw in resp_text[0] for kw in keywords)
-
-    async def _on_close(self) -> None:
-        """
-        Save cookies to the state manager before closing.
-        """
-        state_mgr.set_cookies("yamibo", self.cookies)

--- a/novel_downloader/core/requesters/yamibo/session.py
+++ b/novel_downloader/core/requesters/yamibo/session.py
@@ -10,7 +10,6 @@ from lxml import etree
 
 from novel_downloader.config.models import RequesterConfig
 from novel_downloader.core.requesters.base import BaseSession
-from novel_downloader.utils.i18n import t
 from novel_downloader.utils.state import state_mgr
 from novel_downloader.utils.time_utils import sleep_with_random_delay
 
@@ -35,32 +34,36 @@ class YamiboSession(BaseSession):
         super().__init__(config)
         self._logged_in: bool = False
         self._request_interval = config.backoff_factor
-        self._retry_times = config.retry_times
-        self._username = config.username
-        self._password = config.password
 
     def login(
         self,
         username: str = "",
         password: str = "",
-        manual_login: bool = False,
+        cookies: dict[str, str] | None = None,
+        attempt: int = 1,
         **kwargs: Any,
     ) -> bool:
         """
         Restore cookies persisted by the session-based workflow.
         """
-        cookies: dict[str, str] = state_mgr.get_cookies("yamibo")
-        username = username or self._username
-        password = password or self._password
+        if cookies:
+            self.update_cookies(cookies)
 
-        self.update_cookies(cookies)
-        for _ in range(self._retry_times):
-            if self._check_login_status():
-                self.logger.debug("[auth] Already logged in.")
+        if self._check_login_status():
+            self._logged_in = True
+            self.logger.debug("[auth] Logged in via cookies.")
+            return True
+
+        if not (username and password):
+            self.logger.warning("[auth] No credentials provided.")
+            return False
+
+        for _ in range(attempt):
+            success = self._api_login(username, password)
+            if success and self._check_login_status():
                 self._logged_in = True
                 return True
-            if username and password and not self._api_login(username, password):
-                print(t("session_login_failed", site="esjzone"))
+
             sleep_with_random_delay(
                 self._request_interval,
                 mul_spread=1.1,

--- a/novel_downloader/core/requesters/yamibo/session.py
+++ b/novel_downloader/core/requesters/yamibo/session.py
@@ -6,11 +6,10 @@ novel_downloader.core.requesters.yamibo.session
 
 from typing import Any
 
-from lxml import etree
+from lxml import html
 
 from novel_downloader.config.models import RequesterConfig
 from novel_downloader.core.requesters.base import BaseSession
-from novel_downloader.utils.state import state_mgr
 from novel_downloader.utils.time_utils import sleep_with_random_delay
 
 
@@ -188,7 +187,7 @@ class YamiboSession(BaseSession):
         try:
             resp_1 = self.get(self.LOGIN_URL)
             resp_1.raise_for_status()
-            tree = etree.HTML(resp_1.text)
+            tree = html.fromstring(resp_1.text)
             csrf_value = tree.xpath('//input[@name="_csrf-frontend"]/@value')
             csrf_value = csrf_value[0] if csrf_value else ""
             if not csrf_value:
@@ -232,9 +231,3 @@ class YamiboSession(BaseSession):
         if not resp_text:
             return False
         return not any(kw in resp_text[0] for kw in keywords)
-
-    def _on_close(self) -> None:
-        """
-        Save cookies to the state manager before closing.
-        """
-        state_mgr.set_cookies("yamibo", self.cookies)

--- a/novel_downloader/core/savers/epub_utils/image_loader.py
+++ b/novel_downloader/core/savers/epub_utils/image_loader.py
@@ -62,7 +62,7 @@ def add_images_from_list(
                 content=content,
             )
             book.add_item(item)
-            logger.info("Embedded image: %s", img_path.name)
+            logger.debug("Embedded image: %s", img_path.name)
         except Exception:
             logger.exception("Failed to embed image %s", img_path)
 
@@ -108,7 +108,7 @@ def add_images_from_dir(
                 content=content,
             )
             book.add_item(item)
-            logger.info("Embedded image: %s", img_path.name)
+            logger.debug("Embedded image: %s", img_path.name)
         except Exception:
             logger.exception("Failed to embed image %s", img_path)
 

--- a/novel_downloader/resources/config/settings.toml
+++ b/novel_downloader/resources/config/settings.toml
@@ -4,7 +4,7 @@ retry_times = 3                    # 请求失败重试次数
 backoff_factor = 2.0
 timeout = 30.0                     # 页面加载超时时间 (秒)
 max_connections = 10               # 并发连接的最大数 (async)
-# max_rps =                        # 最大请求速率 (requests per second), 为空则不限制
+# max_rps =                        # 最大请求速率 (requests per second), 如不设置则请注释掉本行
 
 # DrissionPage 专用设置
 headless = false                   # 是否以无头模式启动浏览器
@@ -105,7 +105,7 @@ book_ids = [
   "0000000000",
   "0000000000"
 ]
-mode = "session"                   # async / session
+mode = "session"
 split_mode = "book"                # 导出方式: book / volume
 login_required = false
 

--- a/novel_downloader/utils/cookies.py
+++ b/novel_downloader/utils/cookies.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""
+novel_downloader.utils.cookies
+------------------------------
+
+Utility for normalizing cookie input from user configuration.
+"""
+
+from collections.abc import Mapping
+from http.cookies import SimpleCookie
+
+
+def resolve_cookies(cookies: str | Mapping[str, str]) -> dict[str, str]:
+    """
+    Parse cookies from a string or dictionary into a standard dictionary.
+
+    Supports input like:
+        - "key1=value1; key2=value2"
+        - {"key1": "value1", "key2": "value2"}
+
+    :param cookies: Cookie string or dict-like object (e.g., from config)
+    :return: A normalized cookie dictionary (key -> value)
+    :raises TypeError: If the input is neither string nor dict-like
+    """
+    if isinstance(cookies, str):
+        filtered = "; ".join(pair for pair in cookies.split(";") if "=" in pair)
+        parsed = SimpleCookie()
+        parsed.load(filtered)
+        return {k: v.value for k, v in parsed.items()}
+    elif isinstance(cookies, Mapping):
+        return {str(k).strip(): str(v).strip() for k, v in cookies.items()}
+    raise TypeError("Unsupported cookie format: must be str or dict-like")

--- a/novel_downloader/utils/hash_store.py
+++ b/novel_downloader/utils/hash_store.py
@@ -100,7 +100,7 @@ class ImageHashStore:
         """Load store from disk and rebuild BK-Tree index."""
         if not self._path.exists():
             self._hash.clear()
-            logger.info(
+            logger.debug(
                 "[ImageHashStore] No file found at %s, starting empty.", self._path
             )
             return
@@ -118,7 +118,7 @@ class ImageHashStore:
         for lbl, hs in self._hash.items():
             for h in hs:
                 self._hash_to_labels.setdefault(h, []).append(lbl)
-        logger.info(
+        logger.debug(
             "[ImageHashStore] Loaded hash store from %s with %d hashes",
             self._path,
             sum(len(v) for v in self._hash.values()),
@@ -134,7 +134,7 @@ class ImageHashStore:
                 self._bk_root = _BKNode(h)
             else:
                 self._bk_root.add(h, self._hd)
-        logger.info(
+        logger.debug(
             "[ImageHashStore] BK-tree index built with %d unique hashes",
             len(self._hash_to_labels),
         )
@@ -148,7 +148,7 @@ class ImageHashStore:
         else:
             txt = json.dumps(data, ensure_ascii=False, indent=2)
             self._path.write_text(txt, encoding="utf-8")
-        logger.info("[ImageHashStore] Saved hash store to %s", self._path)
+        logger.debug("[ImageHashStore] Saved hash store to %s", self._path)
 
     def _maybe_save(self) -> None:
         if self._auto:

--- a/tests/config/test_models.py
+++ b/tests/config/test_models.py
@@ -41,8 +41,6 @@ EXPECTED_FIELDS = {
         "mode": ModeType,
         "max_connections": int,
         "max_rps": float | None,
-        "username": str,
-        "password": str,
     },
     DownloaderConfig: {
         "request_interval": float,
@@ -57,6 +55,8 @@ EXPECTED_FIELDS = {
         "mode": ModeType,
         "storage_backend": StorageBackend,
         "storage_batch_size": int,
+        "username": str,
+        "password": str,
     },
     ParserConfig: {
         "cache_dir": str,

--- a/tests/utils/test_hash_store.py
+++ b/tests/utils/test_hash_store.py
@@ -28,7 +28,7 @@ def test_bknode_add_and_query_simple():
 def test_load_empty_store(tmp_path, caplog):
     """Loading when no file exists should start empty with info log."""
     store_path = tmp_path / "empty.json"
-    caplog.set_level(logging.INFO)
+    caplog.set_level(logging.DEBUG)
     store = ImageHashStore(
         path=store_path,
         auto_save=False,


### PR DESCRIPTION
This PR moves login responsibility from the `requester` module to the `downloader`, simplifying the `requester` to focus solely on API interactions and improving separation of concerns.