### PR TITLE
feat(download): support partial chapter download with start_id and end_id

### DIFF
--- a/docs/3-settings-schema.md
+++ b/docs/3-settings-schema.md
@@ -1,6 +1,10 @@
 ## `settings.toml` 配置说明
 
+> **提示**: 可根据实际需求在 `settings.toml` 中增删字段, 未列出的配置项可参考源码注释或自行扩展。
+
 ### requests 配置
+
+控制网络请求行为, 包括超时 / 重试 / 并发连接数等选项
 
 | 参数名            | 类型    | 默认值          | 说明                                   |
 |------------------|--------|---------------|--------------------------------------|
@@ -16,9 +20,30 @@
 >
 > 建议根据具体站点的响应情况, 适当调低请求速率参数 (`max_rps`), 或稍后重新运行程序继续执行 (工具支持断点续爬, 已完成的数据不会被重复抓取)。
 
+#### 示例配置
+
+```toml
+[requests]
+retry_times = 3
+backoff_factor = 2.0
+timeout = 30.0
+max_connections = 10
+max_rps = 1.0                  # 每秒最多 1 次请求, 可用于限制站点压力
+verify_ssl = true
+browser_type = "chromium"
+
+# 可选项
+headless = false               # 是否使用无头浏览器
+disable_images = false         # 是否禁用图片加载
+```
+
+---
+
 ### general 配置
 
 全局通用行为设置, 包括下载控制 / 目录结构 / 存储方式与调试选项等
+
+#### 主配置项
 
 | 参数名               | 类型    | 默认值              | 说明                                   |
 |---------------------|--------|-------------------|--------------------------------------|
@@ -57,19 +82,127 @@
 | `ocr_weight`      | float        | 0.5        | 最终结果中 OCR 部分的权重                                |
 | `vec_weight`      | float        | 0.5        | 最终结果中向量识别部分的权重                             |
 
+#### 示例配置
+
+```toml
+[general]
+request_interval = 2.0
+raw_data_dir = "./raw_data"
+output_dir = "./downloads"
+cache_dir = "./novel_cache"
+download_workers = 2
+parser_workers = 2
+skip_existing = true
+storage_backend = "sqlite"
+storage_batch_size = 30
+
+[general.debug]
+save_html = false
+log_level = "INFO"
+
+[general.font_ocr]
+decode_font = false
+use_freq = false
+ocr_version = "v2.0"
+use_ocr = true
+use_vec = false
+save_font_debug = false
+batch_size = 32
+gpu_mem = 500
+# gpu_id = 0
+ocr_weight = 0.5
+vec_weight = 0.5
+```
+
+---
+
 ### sites 配置
 
-针对不同网站的专属配置, 通过站点名称区分 (如 `qidian`、`xxxxx` 等)
+针对不同网站的专属配置, 通过站点名称区分 (如 `<site>` 可以是 `qidian`、`xxxxx` 等)
+
+每个站点配置位于 `[sites.<site>]` 下:
 
 | 参数名           | 类型             | 默认值        | 说明                                                           |
 |------------------|------------------|---------------|----------------------------------------------------------------|
-| `book_ids`        | array[string]     | -             | 小说 ID 列表 (如 `1010868264`)                                 |
+| `book_ids`        | array\<string\> 或 array\<table\>     | -             | 小说 ID 列表 (如 `1010868264`)                                 |
 | `mode`            | string            | `"browser"`   | 请求方式: `browser` / `session` /                             |
 | `login_required`  | bool              | false         | 是否需要登录才能访问                                           |
+
+#### `book_ids` 字段说明
+
+`book_ids` 字段支持以下两种格式:
+
+1. 简单 ID 列表
+
+```toml
+[sites.<site>]
+book_ids = [
+  "1010868264",
+  "1020304050"
+]
+```
+
+2. 结构化配置 (支持章节范围与忽略列表)
+
+```toml
+[sites.<site>]
+mode = "session"
+login_required = true
+
+[[sites.<site>.book_ids]]
+book_id = "1030412702"
+start_id = "833888839"
+end_id = "921312343"
+ignore_ids = ["1234563", "43212314"]
+
+[[sites.<site>.book_ids]]
+book_id = "1111111111"
+# 其他字段可省略
+```
+
+每个结构化的 `book_id` 支持以下字段：
+
+| 字段名          | 类型            | 必需 | 说明               |
+| ------------ | ------------- | -- | ---------------- |
+| `book_id`    | string        | 是  | 小说的唯一标识 ID       |
+| `start_id`   | string        | 否  | 起始章节 ID，从该章节开始下载 |
+| `end_id`     | string        | 否  | 结束章节 ID，下载至该章节为止 |
+| `ignore_ids` | `list[string]` | 否  | 要跳过的章节 ID 列表     |
+
+#### 示例: 起点中文网配置
+
+```toml
+# 简单格式
+[sites.qidian]
+book_ids = [
+  "1010868264",
+  "1012584111"
+]
+mode = "session"
+login_required = true
+```
+
+```toml
+# 结构化格式
+[sites.qidian]
+mode = "session"
+login_required = true
+
+[[sites.qidian.book_ids]]
+book_id = "1010868264"
+start_id = "434742822"
+end_id = "528536599"
+ignore_ids = ["507161874", "516065132"]
+
+[[sites.qidian.book_ids]]
+book_id = "1012584111"
+```
 
 ### output 配置
 
 控制输出格式 / 文件命名规则以及生成文件的内容设置
+
+#### 主配置项
 
 | 参数名                         | 类型     | 默认值                          | 说明                                       |
 |-------------------------------|---------|-------------------------------|-------------------------------------------|
@@ -99,4 +232,24 @@
 | `include_toc`                 | bool    | true                          | 是否自动生成章节目录                        |
 | `include_picture`             | bool    | false                         | 是否下载并嵌入章节中的图片 (可能增加文件体积) |
 
-> **提示**: 可根据实际需求在 `settings.toml` 中增删字段, 未列出的配置项可参考源码注释或自行扩展。
+#### 示例配置
+
+```toml
+[output]
+clean_text = true
+
+[output.formats]
+make_txt = true
+make_epub = false
+make_md = false
+make_pdf = false
+
+[output.naming]
+append_timestamp = false
+filename_template = "{title}_{author}"
+
+[output.epub]
+include_cover = true
+include_toc = false
+include_picture = false
+```

--- a/docs/4-supported-sites.md
+++ b/docs/4-supported-sites.md
@@ -51,39 +51,60 @@ Book ID 通常来源于小说详情页 URL 中的路径段, 各资源站点的�
 
 * **起点中文网 (qidian)**
 
-  示例 URL: `https://www.qidian.com/book/1010868264/` -> Book ID: `1010868264`
+  示例 URL:
+
+    - 书籍页面: `https://www.qidian.com/book/1010868264/` -> Book ID: `1010868264`
+    - 章节页面: `https://www.qidian.com/chapter/1010868264/405976997/` -> Chapter ID: `405976997`
 
   该站点需提供有效的 Cookie 才能访问订阅章节。
 
 * **笔趣阁 (biquge)**
 
-  示例 URL: `http://www.b520.cc/8_8187/` -> Book ID: `8_8187`
+  示例 URL:
+
+    - 书籍页面: `http://www.b520.cc/8_8187/` -> Book ID: `8_8187`
+    - 章节页面: `http://www.b520.cc/8_8187/3899831.html` -> Chapter ID: `3899831`
 
   该站点无需额外认证即可获取小说内容。
 
 * **铅笔小说 (qianbi)**
 
-  示例 URL: `https://www.23qb.net/book/12282/` -> Book ID: `12282`
+  示例 URL:
+
+    - 书籍页面: `https://www.23qb.net/book/12282/` -> Book ID: `12282`
+    - 章节页面: `https://www.23qb.net/book/12282/7908999.html` -> Chapter ID: `7908999`
 
 * **SF 轻小说 (sfacg)**
 
-  示例 URL: `https://m.sfacg.com/b/456123/` -> Book ID: `456123`
+  示例 URL:
+
+    - 书籍页面: `https://m.sfacg.com/b/456123/` -> Book ID: `456123`
+    - 章节页面: `https://m.sfacg.com/c/5417665/` -> Chapter ID: `5417665`
 
   该站点需提供有效的 Cookie 才能访问订阅章节。
 
 * **ESJ Zone (esjzone)**
 
-  示例 URL: `https://www.esjzone.cc/detail/1660702902.html` -> Book ID: `1660702902`
+  示例 URL:
+
+    - 书籍页面: `https://www.esjzone.cc/detail/1660702902.html` -> Book ID: `1660702902`
+    - 章节页面: `https://www.esjzone.cc/forum/1660702902/294593.html` -> Chapter ID: `294593`
 
   **注意**: 若未完成登录验证, 部分小说页面会自动重定向至「論壇」页面, 导致内容加载失败。
 
 * **百合会 (yamibo)**
 
-  示例 URL: `https://www.yamibo.com/novel/262117` -> Book ID: `262117`
+  示例 URL:
+
+    - 书籍页面: `https://www.yamibo.com/novel/262117` -> Book ID: `262117`
+    - 章节页面: `https://www.qidian.com/chapter/1010868264/405976997/` -> Chapter ID: `405976997`
 
 * **哔哩轻小说 (linovelib)**
 
-  示例 URL: `https://www.linovelib.com/novel/1234.html` -> Book ID: `1234`
+  示例 URL:
+
+    - 书籍页面: `https://www.linovelib.com/novel/1234.html` -> Book ID: `1234`
+    - 章节页面: `https://www.linovelib.com/novel/1234/47800.html` -> Chapter ID: `47800`
 
   该站点对于频繁请求有访问限制, 若请求间隔过短, 可能触发风控机制, 导致账号或设备被封禁或限制访问。
 

--- a/docs/6-cli-usage-examples.md
+++ b/docs/6-cli-usage-examples.md
@@ -65,14 +65,23 @@ Commands:
 按书籍 ID 下载完整小说, 支持从命令行或配置文件读取 ID:
 
 ```bash
-novel-cli download [-h] [--site SITE] [--config CONFIG] [book_ids ...]
+novel-cli download [-h] [--site SITE] [--config CONFIG] [--start START] [--end END] [book_ids ...]
 ```
 
 **参数说明**:
 
 * `book_ids`: 要下载的书籍 ID (可选, 省略时将从配置文件读取)
 * `--site [qidian|biquge|...]`: 站点名称缩写, 默认 `qidian`
+* `--config`: 指定配置文件路径, 覆盖默认 `settings.toml` 配置
+* `--start`: 下载起始章节 ID (仅用于第一个书籍 ID)
+* `--end`: 下载结束章节 ID (包含在内, 仅用于第一个书籍 ID)
 * `--help`: 显示帮助信息
+
+> CLI 中的 `--start` / `--end` 用于临时下载部分章节, 仅影响**第一个**命令行提供的 `book_id`。
+>
+> `--start` 和 `--end` 接收的是章节的 **唯一 ID**, 并非 "第几章" 的序号。可参考 [`supported-sites.md`](./4-supported-sites.md) 内说明。
+>
+> 若要配置更复杂的范围或忽略章节, 请使用配置文件中的结构化 `book_ids` 格式 (参见 [配置文件说明](./3-settings-schema.md))。
 
 **示例**:
 
@@ -82,6 +91,9 @@ novel-cli download 1234567890
 
 # 指定站点 (如 biquge)
 novel-cli download --site biquge 8_8187
+
+# 只下载起点小说的一部分章节
+novel-cli download --start 10001 --end 10200 1234567890
 
 # 从配置文件中读取 ID
 novel-cli download

--- a/novel_downloader/cli/download.py
+++ b/novel_downloader/cli/download.py
@@ -9,6 +9,7 @@ Download novels from supported sites via CLI.
 import asyncio
 import getpass
 from argparse import Namespace, _SubParsersAction
+from collections.abc import Iterable
 from dataclasses import asdict
 from pathlib import Path
 from typing import Any
@@ -21,7 +22,7 @@ from novel_downloader.core.factory import (
     get_parser,
 )
 from novel_downloader.core.interfaces import FetcherProtocol
-from novel_downloader.models import LoginField
+from novel_downloader.models import BookConfig, LoginField
 from novel_downloader.utils.cookies import resolve_cookies
 from novel_downloader.utils.i18n import t
 from novel_downloader.utils.logger import setup_logging
@@ -36,6 +37,9 @@ def register_download_subcommand(subparsers: _SubParsersAction) -> None:  # type
     )
     parser.add_argument("--config", type=str, help=t("help_config"))
 
+    parser.add_argument("--start", type=str, help=t("download_option_start"))
+    parser.add_argument("--end", type=str, help=t("download_option_end"))
+
     parser.set_defaults(func=handle_download)
 
 
@@ -44,7 +48,11 @@ def handle_download(args: Namespace) -> None:
 
     site: str = args.site
     config_path: Path | None = Path(args.config) if args.config else None
-    book_ids: list[str] = args.book_ids or []
+    book_ids: list[BookConfig] = _cli_args_to_book_configs(
+        args.book_ids,
+        args.start,
+        args.end,
+    )
 
     print(t("download_site_info", site=site))
 
@@ -63,8 +71,7 @@ def handle_download(args: Namespace) -> None:
             print(t("download_fail_get_ids", err=str(e)))
             return
 
-    invalid_ids = {"0000000000"}
-    valid_book_ids = set(book_ids) - invalid_ids
+    valid_book_ids = _filter_valid_book_configs(book_ids)
 
     if not book_ids:
         print(t("download_no_ids"))
@@ -78,10 +85,59 @@ def handle_download(args: Namespace) -> None:
     asyncio.run(_download(adapter, site, valid_book_ids))
 
 
+def _cli_args_to_book_configs(
+    book_ids: list[str],
+    start_id: str | None,
+    end_id: str | None,
+) -> list[BookConfig]:
+    """
+    Convert CLI book_ids and optional --start/--end into a list of BookConfig.
+    Only the first book_id uses start/end; others are minimal.
+    """
+    if not book_ids:
+        return []
+
+    result: list[BookConfig] = []
+
+    first: BookConfig = {"book_id": book_ids[0]}
+    if start_id:
+        first["start_id"] = start_id
+    if end_id:
+        first["end_id"] = end_id
+    result.append(first)
+
+    for book_id in book_ids[1:]:
+        result.append({"book_id": book_id})
+
+    return result
+
+
+def _filter_valid_book_configs(
+    books: list[BookConfig],
+    invalid_ids: Iterable[str] = ("0000000000",),
+) -> list[BookConfig]:
+    """
+    Filter a list of BookConfig:
+    - Removes entries with invalid or placeholder book_ids
+    - Deduplicates based on book_id while preserving order
+    """
+    seen = set(invalid_ids)
+    result: list[BookConfig] = []
+
+    for book in books:
+        book_id = book["book_id"]
+        if book_id in seen:
+            continue
+        seen.add(book_id)
+        result.append(book)
+
+    return result
+
+
 async def _download(
     adapter: ConfigAdapter,
     site: str,
-    valid_book_ids: set[str],
+    valid_book_ids: list[BookConfig],
 ) -> None:
     downloader_cfg = adapter.get_downloader_config()
     fetcher_cfg = adapter.get_fetcher_config()
@@ -112,7 +168,10 @@ async def _download(
 
         for book_id in valid_book_ids:
             print(t("download_downloading", book_id=book_id, site=site))
-            await downloader.download(book_id, progress_hook=_print_progress)
+            await downloader.download(
+                book_id["book_id"],
+                progress_hook=_print_progress,
+            )
 
         if downloader_cfg.login_required and fetcher.is_logged_in:
             await fetcher.save_state()

--- a/novel_downloader/cli/download.py
+++ b/novel_downloader/cli/download.py
@@ -71,18 +71,18 @@ def handle_download(args: Namespace) -> None:
             print(t("download_fail_get_ids", err=str(e)))
             return
 
-    valid_book_ids = _filter_valid_book_configs(book_ids)
+    valid_books = _filter_valid_book_configs(book_ids)
 
     if not book_ids:
         print(t("download_no_ids"))
         return
 
-    if not valid_book_ids:
+    if not valid_books:
         print(t("download_only_example", example="0000000000"))
         print(t("download_edit_config"))
         return
 
-    asyncio.run(_download(adapter, site, valid_book_ids))
+    asyncio.run(_download(adapter, site, valid_books))
 
 
 def _cli_args_to_book_configs(
@@ -137,7 +137,7 @@ def _filter_valid_book_configs(
 async def _download(
     adapter: ConfigAdapter,
     site: str,
-    valid_book_ids: list[BookConfig],
+    valid_books: list[BookConfig],
 ) -> None:
     downloader_cfg = adapter.get_downloader_config()
     fetcher_cfg = adapter.get_fetcher_config()
@@ -166,10 +166,10 @@ async def _download(
             config=downloader_cfg,
         )
 
-        for book_id in valid_book_ids:
-            print(t("download_downloading", book_id=book_id, site=site))
+        for book in valid_books:
+            print(t("download_downloading", book_id=book["book_id"], site=site))
             await downloader.download(
-                book_id["book_id"],
+                book,
                 progress_hook=_print_progress,
             )
 

--- a/novel_downloader/core/interfaces/downloader.py
+++ b/novel_downloader/core/interfaces/downloader.py
@@ -10,45 +10,46 @@ that outlines the expected behavior of any downloader class.
 from collections.abc import Awaitable, Callable
 from typing import Any, Protocol, runtime_checkable
 
+from novel_downloader.models import BookConfig
+
 
 @runtime_checkable
 class DownloaderProtocol(Protocol):
     """
-    Protocol for fully-asynchronous downloader classes.
+    Protocol for async downloader implementations.
 
-    Defines the expected interface for any downloader implementation,
-    including both batch and single book downloads,
-    as well as optional pre-download hooks.
+    Uses BookConfig (with book_id, optional start_id/end_id/ignore_ids)
+    for both single and batch downloads.
     """
 
     async def download(
         self,
-        book_id: str,
+        book: BookConfig,
         *,
         progress_hook: Callable[[int, int], Awaitable[None]] | None = None,
         **kwargs: Any,
     ) -> None:
         """
-        Download logic for a single book.
+        Download a single book.
 
-        :param book_id: The identifier of the book.
-        :param progress_hook: (optional) Called after each chapter;
+        :param book: BookConfig with at least 'book_id'.
+        :param progress_hook: Optional async callback after each chapter.
                                 args: completed_count, total_count.
         """
         ...
 
     async def download_many(
         self,
-        book_ids: list[str],
+        books: list[BookConfig],
         *,
         progress_hook: Callable[[int, int], Awaitable[None]] | None = None,
         **kwargs: Any,
     ) -> None:
         """
-        Batch download entry point.
+        Download multiple books.
 
-        :param book_ids: List of book IDs to download.
-        :param progress_hook: (optional) Called after each chapter;
+        :param books: List of BookConfig entries.
+        :param progress_hook: Optional async callback after each chapter.
                                 args: completed_count, total_count.
         """
         ...

--- a/novel_downloader/locales/en.json
+++ b/novel_downloader/locales/en.json
@@ -66,6 +66,8 @@
   "download_downloading": "Downloading book {book_id} from {site}...",
   "download_prompt_parse": "Parse...",
   "download_book_ids": "One or more book IDs to process",
+  "download_option_start": "Start chapter ID (applies to the first book ID only)",
+  "download_option_end": "End chapter ID (applies to the first book ID only)",
   "login_description": "Description",
   "login_hint": "Hint",
   "login_manual_prompt": ">> Please complete login in your browser and press Enter to continue...",

--- a/novel_downloader/locales/zh.json
+++ b/novel_downloader/locales/zh.json
@@ -66,6 +66,8 @@
   "download_downloading": "正在从 {site} 下载书籍 {book_id}...",
   "download_prompt_parse": "结束...",
   "download_book_ids": "要处理的一个或多个小说 ID",
+  "download_option_start": "起始章节 ID (仅用于第一个书籍 ID)",
+  "download_option_end": "结束章节 ID (仅用于第一个书籍 ID)",
   "login_description": "说明",
   "login_hint": "提示",
   "login_manual_prompt": ">> 请在浏览器中完成登录后按回车继续...",

--- a/novel_downloader/models/__init__.py
+++ b/novel_downloader/models/__init__.py
@@ -8,6 +8,7 @@ novel_downloader.models
 from .browser import NewContextOptions
 from .chapter import ChapterDict
 from .config import (
+    BookConfig,
     DownloaderConfig,
     ExporterConfig,
     FetcherConfig,
@@ -39,6 +40,7 @@ from .types import (
 
 __all__ = [
     "NewContextOptions",
+    "BookConfig",
     "DownloaderConfig",
     "ParserConfig",
     "FetcherConfig",

--- a/novel_downloader/models/config.py
+++ b/novel_downloader/models/config.py
@@ -17,6 +17,7 @@ strongly typed Python objects for safer and cleaner access.
 """
 
 from dataclasses import dataclass
+from typing import NotRequired, TypedDict
 
 from .types import (
     BrowserType,
@@ -98,3 +99,10 @@ class ExporterConfig:
     include_toc: bool = False
     include_picture: bool = False
     split_mode: SplitMode = "book"
+
+
+class BookConfig(TypedDict):
+    book_id: str
+    start_id: NotRequired[str]
+    end_id: NotRequired[str]
+    ignore_ids: NotRequired[list[str]]

--- a/novel_downloader/tui/screens/home.py
+++ b/novel_downloader/tui/screens/home.py
@@ -106,12 +106,12 @@ class HomeScreen(Screen):  # type: ignore[misc]
         self,
         adapter: ConfigAdapter,
         site: str,
-        valid_book_ids: set[str],
+        book_ids: set[str],
     ) -> None:
         btn = self.query_one("#download", Button)
         btn.disabled = True
         try:
-            logging.info(f"下载请求: {site} | {valid_book_ids}")
+            logging.info(f"下载请求: {site} | {book_ids}")
             downloader_cfg = adapter.get_downloader_config()
             fetcher_cfg = adapter.get_fetcher_config()
             parser_cfg = adapter.get_parser_config()
@@ -139,10 +139,11 @@ class HomeScreen(Screen):  # type: ignore[misc]
                     config=downloader_cfg,
                 )
 
-                for book_id in valid_book_ids:
+                for book_id in book_ids:
                     logging.info(t("download_downloading", book_id=book_id, site=site))
                     await downloader.download(
-                        book_id, progress_hook=self._update_progress
+                        {"book_id": book_id},
+                        progress_hook=self._update_progress,
                     )
 
                 if downloader_cfg.login_required and fetcher.is_logged_in:


### PR DESCRIPTION
### Summary

This PR introduces support for downloading a specific chapter range from a book, as proposed in [#36](https://github.com/BowenZ217/novel-downloader/issues/36).

### What‘s Added

1. Defined `BookConfig` in the module to structure book metadata, including:
   - `book_id` (required)
   - `start_id`, `end_id`, `ignore_ids` (optional)

2. Extended CLI with the following arguments:
   - `--start`: starting chapter ID (applies to the first book only)
   - `--end`: ending chapter ID (applies to the first book only)

3. Updated the downloader logic to support partial downloads:
   - Skips chapters until `chapter_id == start_id`
   - Stops when `chapter_id == end_id` (inclusive)
   - Skips any chapter listed in `ignore_ids`
   - If `start_id` or `end_id` is not found, fallback behavior applies (downloads none or continues to end)

### Related Issue

Resolves #36 -- Implements CLI chapter range download.