### PR TITLE
fix(fetcher): close pages in finally block to prevent leak on failures

### DIFF
--- a/novel_downloader/core/fetchers/esjzone/browser.py
+++ b/novel_downloader/core/fetchers/esjzone/browser.py
@@ -49,15 +49,17 @@ class EsjzoneBrowser(BaseBrowser):
 
         login_page = await self.context.new_page()
 
-        await login_page.goto(self.API_LOGIN_URL_1, wait_until="networkidle")
+        try:
+            await login_page.goto(self.API_LOGIN_URL_1, wait_until="networkidle")
 
-        await login_page.fill('input[name="email"]', username)
-        await login_page.fill('input[name="pwd"]', password)
+            await login_page.fill('input[name="email"]', username)
+            await login_page.fill('input[name="pwd"]', password)
 
-        await login_page.click('a.btn-send[data-send="mem_login"]')
+            await login_page.click('a.btn-send[data-send="mem_login"]')
 
-        await login_page.wait_for_load_state("networkidle")
-        await login_page.close()
+            await login_page.wait_for_load_state("networkidle")
+        finally:
+            await login_page.close()
 
         self._is_logged_in = await self._check_login_status()
 

--- a/novel_downloader/core/fetchers/yamibo/browser.py
+++ b/novel_downloader/core/fetchers/yamibo/browser.py
@@ -48,8 +48,8 @@ class YamiboBrowser(BaseBrowser):
             return False
 
         for i in range(1, attempt + 1):
+            login_page = await self.context.new_page()
             try:
-                login_page = await self.context.new_page()
                 await login_page.goto(self.LOGIN_URL, wait_until="networkidle")
 
                 await login_page.fill("#loginform-username", username)
@@ -68,8 +68,6 @@ class YamiboBrowser(BaseBrowser):
                         f"[auth] No URL change after login attempt {i}: {e}"
                     )
 
-                await login_page.close()
-
                 self._is_logged_in = await self._check_login_status()
                 if self._is_logged_in:
                     self.logger.info(f"[auth] Login successful on attempt {i}.")
@@ -83,6 +81,8 @@ class YamiboBrowser(BaseBrowser):
                 self.logger.error(
                     f"[auth] Unexpected error during login attempt {i}: {e}"
                 )
+            finally:
+                await login_page.close()
 
         self.logger.error(f"[auth] Login failed after {attempt} attempt(s).")
         return False


### PR DESCRIPTION
### Description

Wrap the new-page lifecycle in a `try/finally` block so that any exception during navigation or content retrieval still triggers `page.close()`. This change ensures that pages are not left open unintentionally.

### Motivation

* In the previous implementation, an exception raised by `goto()` or `content()` could skip the subsequent `page.close()`, causing page objects to linger and consume sockets or memory.
* Enforcing cleanup in a `finally` block eliminates this leak risk and preserves browser stability.