### PR TITLE
chore(github): add default pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,33 @@
+### Description
+
+<!-- A clear and concise description of what this PR does -->
+
+---
+
+### Changes
+
+<!-- Bullet points outlining what was changed -->
+
+---
+
+### Motivation
+
+<!-- Why this change is necessary or beneficial -->
+
+---
+
+### Related Issues
+
+Fixes # (issue)
+
+---
+
+### Type of change
+
+Please delete options that are not relevant.
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Refactor (non-breaking change that improves structure or readability)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] This change requires a documentation update


### PR DESCRIPTION
### Summary

Add a default PR template to enforce consistency and improve clarity in pull request descriptions.

---

### Type of change

- [x] Documentation update

---

### Changes

- Added `.github/PULL_REQUEST_TEMPLATE.md`
- Included sections: Summary, Type of change, Motivation