### PR TITLE
refactor(downloader): separate exporter from download flow

### DIFF
--- a/docs/api/core/README.md
+++ b/docs/api/core/README.md
@@ -44,19 +44,27 @@ fetcher_cfg = FetcherConfig(...)
 parser_cfg  = ParserConfig(...)
 exporter_cfg = ExporterConfig(...)
 downloader_cfg = DownloaderConfig(...)
+book_config = {
+    "book_id": 12345,
+}
+
+# 创建 Parser/Exporter
+parser   = get_parser("qidian", parser_cfg)
+exporter = get_exporter("qidian", exporter_cfg)
 
 # 异步上下文中创建并登录 Fetcher
 async with get_fetcher("qidian", fetcher_cfg) as fetcher:
     await fetcher.login(username, password)
 
-    # 创建 Parser/Exporter
-    parser   = get_parser("qidian", parser_cfg)
-    exporter = get_exporter("qidian", exporter_cfg)
-
-    # 下载并导出整本书
+    # 下载整本书
     downloader = get_downloader(
-        fetcher, parser, exporter,
-        site="qidian", config=downloader_cfg
+        fetcher,
+        parser,
+        site="qidian",
+        config=downloader_cfg,
     )
     await downloader.download(book_config, progress_hook=progress_hook)
+
+# 导出整本书
+exporter.export(book["book_id"])
 ```

--- a/docs/api/core/downloaders.md
+++ b/docs/api/core/downloaders.md
@@ -16,12 +16,12 @@
 from novel_downloader.core.downloaders import QidianDownloader
 ```
 
-描述: 直接导入站点专用的 Downloader 类, 初始化需传入 `fetcher`、`parser`、`exporter` 和 `config`
+描述: 直接导入站点专用的 Downloader 类, 初始化需传入 `fetcher`、`parser` 和 `config`
 
 示例:
 
 ```python
-downloader = QidianDownloader(fetcher, parser, exporter, downloader_cfg)
+downloader = QidianDownloader(fetcher, parser, downloader_cfg)
 ```
 
 ---
@@ -42,7 +42,6 @@ async with get_fetcher(site, fetcher_cfg) as fetcher:
     downloader = get_downloader(
         fetcher=fetcher,
         parser=parser,
-        exporter=exporter,
         site=site,
         config=downloader_cfg,
     )
@@ -52,6 +51,8 @@ async with get_fetcher(site, fetcher_cfg) as fetcher:
         book_config,
         progress_hook=_print_progress,
     )
+    # 导出保存为 txt / epub
+    exporter.export(book_id)
 
     # 批量下载多本书
     await downloader.download_many(

--- a/novel_downloader/cli/download.py
+++ b/novel_downloader/cli/download.py
@@ -161,7 +161,6 @@ async def _download(
         downloader = get_downloader(
             fetcher=fetcher,
             parser=parser,
-            exporter=exporter,
             site=site,
             config=downloader_cfg,
         )
@@ -172,6 +171,7 @@ async def _download(
                 book,
                 progress_hook=_print_progress,
             )
+            await asyncio.to_thread(exporter.export, book["book_id"])
 
         if downloader_cfg.login_required and fetcher.is_logged_in:
             await fetcher.save_state()

--- a/novel_downloader/core/downloaders/base.py
+++ b/novel_downloader/core/downloaders/base.py
@@ -15,7 +15,6 @@ from typing import Any
 
 from novel_downloader.core.interfaces import (
     DownloaderProtocol,
-    ExporterProtocol,
     FetcherProtocol,
     ParserProtocol,
 )
@@ -34,13 +33,11 @@ class BaseDownloader(DownloaderProtocol, abc.ABC):
         self,
         fetcher: FetcherProtocol,
         parser: ParserProtocol,
-        exporter: ExporterProtocol,
         config: DownloaderConfig,
         site: str,
     ):
         self._fetcher = fetcher
         self._parser = parser
-        self._exporter = exporter
         self._config = config
         self._site = site
 
@@ -157,10 +154,6 @@ class BaseDownloader(DownloaderProtocol, abc.ABC):
     @property
     def parser(self) -> ParserProtocol:
         return self._parser
-
-    @property
-    def exporter(self) -> ExporterProtocol:
-        return self._exporter
 
     @property
     def config(self) -> DownloaderConfig:

--- a/novel_downloader/core/downloaders/biquge.py
+++ b/novel_downloader/core/downloaders/biquge.py
@@ -7,7 +7,6 @@ novel_downloader.core.downloaders.biquge
 
 from novel_downloader.core.downloaders.common import CommonDownloader
 from novel_downloader.core.interfaces import (
-    ExporterProtocol,
     FetcherProtocol,
     ParserProtocol,
 )
@@ -21,7 +20,6 @@ class BiqugeDownloader(CommonDownloader):
         self,
         fetcher: FetcherProtocol,
         parser: ParserProtocol,
-        exporter: ExporterProtocol,
         config: DownloaderConfig,
     ):
-        super().__init__(fetcher, parser, exporter, config, "biquge")
+        super().__init__(fetcher, parser, config, "biquge")

--- a/novel_downloader/core/downloaders/common.py
+++ b/novel_downloader/core/downloaders/common.py
@@ -440,8 +440,6 @@ class CommonDownloader(BaseDownloader):
         normal_cs.close()
         save_as_json(book_info, info_path)
 
-        await asyncio.to_thread(self.exporter.export, book_id)
-
         self.logger.info(
             "%s Novel '%s' download completed.",
             TAG,

--- a/novel_downloader/core/downloaders/esjzone.py
+++ b/novel_downloader/core/downloaders/esjzone.py
@@ -7,7 +7,6 @@ novel_downloader.core.downloaders.esjzone
 
 from novel_downloader.core.downloaders.common import CommonDownloader
 from novel_downloader.core.interfaces import (
-    ExporterProtocol,
     FetcherProtocol,
     ParserProtocol,
 )
@@ -21,7 +20,6 @@ class EsjzoneDownloader(CommonDownloader):
         self,
         fetcher: FetcherProtocol,
         parser: ParserProtocol,
-        exporter: ExporterProtocol,
         config: DownloaderConfig,
     ):
-        super().__init__(fetcher, parser, exporter, config, "esjzone")
+        super().__init__(fetcher, parser, config, "esjzone")

--- a/novel_downloader/core/downloaders/linovelib.py
+++ b/novel_downloader/core/downloaders/linovelib.py
@@ -7,7 +7,6 @@ novel_downloader.core.downloaders.linovelib
 
 from novel_downloader.core.downloaders.common import CommonDownloader
 from novel_downloader.core.interfaces import (
-    ExporterProtocol,
     FetcherProtocol,
     ParserProtocol,
 )
@@ -21,7 +20,6 @@ class LinovelibDownloader(CommonDownloader):
         self,
         fetcher: FetcherProtocol,
         parser: ParserProtocol,
-        exporter: ExporterProtocol,
         config: DownloaderConfig,
     ):
-        super().__init__(fetcher, parser, exporter, config, "linovelib")
+        super().__init__(fetcher, parser, config, "linovelib")

--- a/novel_downloader/core/downloaders/qianbi.py
+++ b/novel_downloader/core/downloaders/qianbi.py
@@ -7,7 +7,6 @@ novel_downloader.core.downloaders.qianbi
 
 from novel_downloader.core.downloaders.common import CommonDownloader
 from novel_downloader.core.interfaces import (
-    ExporterProtocol,
     FetcherProtocol,
     ParserProtocol,
 )
@@ -21,7 +20,6 @@ class QianbiDownloader(CommonDownloader):
         self,
         fetcher: FetcherProtocol,
         parser: ParserProtocol,
-        exporter: ExporterProtocol,
         config: DownloaderConfig,
     ):
-        super().__init__(fetcher, parser, exporter, config, "qianbi")
+        super().__init__(fetcher, parser, config, "qianbi")

--- a/novel_downloader/core/downloaders/qidian.py
+++ b/novel_downloader/core/downloaders/qidian.py
@@ -13,7 +13,6 @@ from typing import Any, cast
 
 from novel_downloader.core.downloaders.base import BaseDownloader
 from novel_downloader.core.interfaces import (
-    ExporterProtocol,
     FetcherProtocol,
     ParserProtocol,
 )
@@ -41,11 +40,10 @@ class QidianDownloader(BaseDownloader):
         self,
         fetcher: FetcherProtocol,
         parser: ParserProtocol,
-        exporter: ExporterProtocol,
         config: DownloaderConfig,
     ):
         config.request_interval = max(1.0, config.request_interval)
-        super().__init__(fetcher, parser, exporter, config, "qidian")
+        super().__init__(fetcher, parser, config, "qidian")
 
     async def _download_one(
         self,
@@ -350,8 +348,6 @@ class QidianDownloader(BaseDownloader):
 
         normal_cs.close()
         encrypted_cs.close()
-
-        await asyncio.to_thread(self.exporter.export, book_id)
 
         self.logger.info(
             "%s Novel '%s' download completed.",

--- a/novel_downloader/core/downloaders/sfacg.py
+++ b/novel_downloader/core/downloaders/sfacg.py
@@ -7,7 +7,6 @@ novel_downloader.core.downloaders.sfacg
 
 from novel_downloader.core.downloaders.common import CommonDownloader
 from novel_downloader.core.interfaces import (
-    ExporterProtocol,
     FetcherProtocol,
     ParserProtocol,
 )
@@ -21,7 +20,6 @@ class SfacgDownloader(CommonDownloader):
         self,
         fetcher: FetcherProtocol,
         parser: ParserProtocol,
-        exporter: ExporterProtocol,
         config: DownloaderConfig,
     ):
-        super().__init__(fetcher, parser, exporter, config, "sfacg")
+        super().__init__(fetcher, parser, config, "sfacg")

--- a/novel_downloader/core/downloaders/yamibo.py
+++ b/novel_downloader/core/downloaders/yamibo.py
@@ -7,7 +7,6 @@ novel_downloader.core.downloaders.yamibo
 
 from novel_downloader.core.downloaders.common import CommonDownloader
 from novel_downloader.core.interfaces import (
-    ExporterProtocol,
     FetcherProtocol,
     ParserProtocol,
 )
@@ -21,7 +20,6 @@ class YamiboDownloader(CommonDownloader):
         self,
         fetcher: FetcherProtocol,
         parser: ParserProtocol,
-        exporter: ExporterProtocol,
         config: DownloaderConfig,
     ):
-        super().__init__(fetcher, parser, exporter, config, "yamibo")
+        super().__init__(fetcher, parser, config, "yamibo")

--- a/novel_downloader/core/factory/downloader.py
+++ b/novel_downloader/core/factory/downloader.py
@@ -22,14 +22,13 @@ from novel_downloader.core.downloaders import (
 )
 from novel_downloader.core.interfaces import (
     DownloaderProtocol,
-    ExporterProtocol,
     FetcherProtocol,
     ParserProtocol,
 )
 from novel_downloader.models import DownloaderConfig
 
 DownloaderBuilder = Callable[
-    [FetcherProtocol, ParserProtocol, ExporterProtocol, DownloaderConfig],
+    [FetcherProtocol, ParserProtocol, DownloaderConfig],
     DownloaderProtocol,
 ]
 
@@ -47,7 +46,6 @@ _site_map: dict[str, DownloaderBuilder] = {
 def get_downloader(
     fetcher: FetcherProtocol,
     parser: ParserProtocol,
-    exporter: ExporterProtocol,
     site: str,
     config: DownloaderConfig,
 ) -> DownloaderProtocol:
@@ -56,7 +54,6 @@ def get_downloader(
 
     :param fetcher: Fetcher implementation
     :param parser: Parser implementation
-    :param exporter: Exporter implementation
     :param site: Site name (e.g., 'qidian')
     :param config: Downloader configuration
 
@@ -66,11 +63,11 @@ def get_downloader(
 
     # site-specific
     if site_key in _site_map:
-        return _site_map[site_key](fetcher, parser, exporter, config)
+        return _site_map[site_key](fetcher, parser, config)
 
     # fallback
     site_rules = load_site_rules()
     if site_key not in site_rules:
         raise ValueError(f"Unsupported site: {site}")
 
-    return CommonDownloader(fetcher, parser, exporter, config, site_key)
+    return CommonDownloader(fetcher, parser, config, site_key)


### PR DESCRIPTION
### Description

This PR decouples the exporter logic from the `downloader.download()` process.

- Removed `exporter.export_as()` call from the `Downloader` class
- Updated CLI and TUI to handle exporting as a separate step
- Now the download process only caches chapter data, and exporting must be done explicitly
- Updated documentation to reflect the new workflow

---

### Changes

#### Code
- `Downloader.download()` no longer invokes `exporter`
- CLI and TUI now prompt/handle export separately after download is complete

#### Docs
- Updated README usage section to describe the new two-step process

---

### Type of change

- [x] Refactor (non-breaking change that improves structure or readability)
- [x] This change requires a documentation update
