### PR TITLE
chore(release): bump version to 1.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## v1.4.3 (2025-06-21)
+
+### Fix
+
+- **qidian**: add use_truncation flag to prevent duplicate chapter content (#45)
+- **fetcher**: close pages in finally block to prevent leak on failures (#41)
+
+### Refactor
+
+- **downloader**: separate exporter from download flow (#47)
+
 ## v1.4.2 (2025-06-14)
 
 ### Feat

--- a/novel_downloader/__init__.py
+++ b/novel_downloader/__init__.py
@@ -6,7 +6,7 @@ novel_downloader
 Core package for the Novel Downloader project.
 """
 
-__version__ = "1.4.2"
+__version__ = "1.4.3"
 
 __author__ = "Saudade Z"
 __email__ = "saudadez217@gmail.com"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,7 +114,7 @@ testpaths = ["tests"]
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "1.4.2"
+version = "1.4.3"
 version_files = [
     "novel_downloader/__init__.py"
 ]


### PR DESCRIPTION
### Description

Bump version from 1.4.2 to 1.4.3 for release.

---

### Changes

- Version bump only

---

### Related Issues

N/A

---

### Type of change

- [x] Chore (release preparation)
