### PR TITLE
fix(qidian): rewrite book info parser for new page structure

### DIFF
--- a/src/novel_downloader/core/fetchers/qidian/browser.py
+++ b/src/novel_downloader/core/fetchers/qidian/browser.py
@@ -22,8 +22,8 @@ class QidianBrowser(BaseBrowser):
 
     HOMEPAGE_URL = "https://www.qidian.com/"
     BOOKCASE_URL = "https://my.qidian.com/bookcase/"
-    BOOK_INFO_URL = "https://book.qidian.com/info/{book_id}/"
-    # BOOK_INFO_URL = "https://www.qidian.com/book/{book_id}/"
+    # BOOK_INFO_URL = "https://book.qidian.com/info/{book_id}/"
+    BOOK_INFO_URL = "https://www.qidian.com/book/{book_id}/"
     CHAPTER_URL = "https://www.qidian.com/chapter/{book_id}/{chapter_id}/"
 
     LOGIN_URL = "https://passport.qidian.com/"

--- a/src/novel_downloader/core/fetchers/qidian/session.py
+++ b/src/novel_downloader/core/fetchers/qidian/session.py
@@ -27,7 +27,8 @@ class QidianSession(BaseSession):
 
     HOMEPAGE_URL = "https://www.qidian.com/"
     BOOKCASE_URL = "https://my.qidian.com/bookcase/"
-    BOOK_INFO_URL = "https://book.qidian.com/info/{book_id}/"
+    # BOOK_INFO_URL = "https://book.qidian.com/info/{book_id}/"
+    BOOK_INFO_URL = "https://www.qidian.com/book/{book_id}/"
     CHAPTER_URL = "https://www.qidian.com/chapter/{book_id}/{chapter_id}/"
 
     LOGIN_URL = "https://passport.qidian.com/"

--- a/src/novel_downloader/core/parsers/qidian/book_info_parser.py
+++ b/src/novel_downloader/core/parsers/qidian/book_info_parser.py
@@ -10,34 +10,17 @@ time, status, word count, summary, and volume-chapter structure.
 """
 
 import logging
+import re
+from datetime import datetime
 from typing import Any
 
 from lxml import html
 
 logger = logging.getLogger(__name__)
 
-_AUTHOR_XPATH = (
-    'string(//div[contains(@class, "book-info")]//a[contains(@class, "writer")])'
-)
-
 
 def _chapter_url_to_id(url: str) -> str:
     return url.rstrip("/").split("/")[-1]
-
-
-def _get_volume_name(
-    vol_elem: html.HtmlElement,
-) -> str:
-    """
-    Extracts the volume title from a <div class="volume"> element using lxml.
-    Ignores <a> tags, and extracts text from other elements.
-    """
-    h3_candidates = vol_elem.xpath(".//h3")
-    if not h3_candidates:
-        return ""
-    texts = vol_elem.xpath(".//h3//text()[not(ancestor::a)]")
-    full_text = "".join(texts).strip()
-    return full_text.split(chr(183))[0].strip()
 
 
 def parse_book_info(html_str: str) -> dict[str, Any]:
@@ -52,59 +35,50 @@ def parse_book_info(html_str: str) -> dict[str, Any]:
     try:
         doc = html.fromstring(html_str)
 
-        book_name = doc.xpath('string(//h1/em[@id="bookName"])').strip()
-        info["book_name"] = book_name
+        info["book_name"] = doc.xpath('string(//h1[@id="bookName"])').strip()
 
-        author = doc.xpath(_AUTHOR_XPATH).strip()
-        info["author"] = author
+        info["author"] = doc.xpath('string(//a[@class="writer-name"])').strip()
 
-        cover_url = doc.xpath('string(//div[@class="book-img"]//img/@src)').strip()
-        info["cover_url"] = cover_url
+        book_id = doc.xpath('//a[@id="bookImg"]/@data-bid')[0]
+        info[
+            "cover_url"
+        ] = f"https://bookcover.yuewen.com/qdbimg/349573/{book_id}/600.webp"
 
-        update_raw = (
-            doc.xpath('string(//span[contains(@class, "update-time")])')
-            .replace("更新时间", "")
+        ut = (
+            doc.xpath('string(//span[@class="update-time"])')
+            .replace("更新时间:", "")
             .strip()
         )
-        info["update_time"] = update_raw
+        if re.match(r"^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$", ut):
+            info["update_time"] = ut
+        else:
+            info["update_time"] = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
 
-        status = doc.xpath('string(//p[@class="tag"]/span[@class="blue"][1])').strip()
-        info["serial_status"] = status
+        info["serial_status"] = doc.xpath(
+            'string(//p[@class="book-attribute"]/span[1])'
+        ).strip()
 
-        tags = doc.xpath('//p[@class="tag"]/a[@class="red"]/text()')
+        tags = doc.xpath('//p[contains(@class,"all-label")]//a/text()')
         info["tags"] = [t.strip() for t in tags if t.strip()]
 
-        wc_number = doc.xpath("string(//p[em and cite][1]/em[1])").strip()
-        wc_unit = doc.xpath("string(//p[em and cite][1]/cite[1])").strip()
-        info["word_count"] = (
-            (wc_number + wc_unit) if wc_number and wc_unit else "Unknown"
-        )
+        info["word_count"] = doc.xpath('string(//p[@class="count"]/em[1])').strip()
 
-        summary = doc.xpath('string(//p[@class="intro"])').strip()
-        info["summary_brief"] = summary
-
-        intro_list = doc.xpath('//div[@class="book-intro"]/p')[0]
-        detail_intro = "\n".join(intro_list.itertext()).strip()
-        info["summary"] = detail_intro
+        raw = doc.xpath('//p[@id="book-intro-detail"]//text()')
+        info["summary_brief"] = "\n".join(line.strip() for line in raw if line.strip())
 
         volumes = []
-        for vol_div in doc.xpath('//div[@class="volume-wrap"]/div[@class="volume"]'):
-            volume_name = _get_volume_name(vol_div)
+        for vol in doc.xpath('//div[@id="allCatalog"]//div[@class="catalog-volume"]'):
+            vol_name = vol.xpath('string(.//h3[@class="volume-name"])').strip()
+            vol_name = vol_name.split(chr(183))[0].strip()
             chapters = []
-            for li in vol_div.xpath(".//li"):
-                a = li.xpath(".//a")[0] if li.xpath(".//a") else None
-                if a is None or "href" not in a.attrib:
-                    continue
-                href = a.attrib["href"].strip()
-                title = "".join(a.itertext()).strip()
+            for li in vol.xpath('.//ul[contains(@class,"volume-chapters")]/li'):
+                a = li.xpath('.//a[@class="chapter-name"]')[0]
+                title = a.text.strip()
+                url = a.get("href")
                 chapters.append(
-                    {
-                        "title": title,
-                        "url": href,
-                        "chapterId": _chapter_url_to_id(href),
-                    }
+                    {"title": title, "url": url, "chapterId": _chapter_url_to_id(url)}
                 )
-            volumes.append({"volume_name": volume_name, "chapters": chapters})
+            volumes.append({"volume_name": vol_name, "chapters": chapters})
         info["volumes"] = volumes
 
     except Exception as e:

--- a/src/novel_downloader/core/parsers/qidian/book_info_parser.py
+++ b/src/novel_downloader/core/parsers/qidian/book_info_parser.py
@@ -63,8 +63,11 @@ def parse_book_info(html_str: str) -> dict[str, Any]:
 
         info["word_count"] = doc.xpath('string(//p[@class="count"]/em[1])').strip()
 
+        summary = doc.xpath('string(//p[@class="intro"])').strip()
+        info["summary_brief"] = summary
+
         raw = doc.xpath('//p[@id="book-intro-detail"]//text()')
-        info["summary_brief"] = "\n".join(line.strip() for line in raw if line.strip())
+        info["summary"] = "\n".join(line.strip() for line in raw if line.strip())
 
         volumes = []
         for vol in doc.xpath('//div[@id="allCatalog"]//div[@class="catalog-volume"]'):

--- a/src/novel_downloader/utils/time_utils/datetime_utils.py
+++ b/src/novel_downloader/utils/time_utils/datetime_utils.py
@@ -138,7 +138,7 @@ def calculate_time_difference(
 
     except Exception as e:
         logger.warning("[time] Failed to calculate time difference: %s", e)
-        return 0, 0, 0, 0
+        return 999, 23, 59, 59
 
 
 __all__ = [


### PR DESCRIPTION
### Description

This PR updates the Qidian fetcher to use the new book info URL, fully rewrites the parser to handle the updated page structure, and adjusts the `calculate_time_difference` function to return a default value on parse failure instead of crashing.

---

### Changes

* **Update** `BOOK_INFO_URL` in Qidian fetchers to `https://www.qidian.com/book/{book_id}/`
* **Rewrite** the book info parser to follow the redirect and correctly extract chapters and metadata from the new HTML layout
* **Modify** `calculate_time_difference` to fall back to a sensible default value when the input time string cannot be parsed

---

### Motivation

Qidian recently rolled out a new version of its book info page that automatically redirects and has a different HTML structure. The old parser could no longer find the expected elements, leading to "list index out of range" and invalid time‐format errors.

---

### Related Issues

Fixes #53

---

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
