### PR TITLE
chore(release): bump version to 1.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## v1.4.4 (2025-07-12)
+
+### Fix
+
+- **qidian**: rewrite book info parser for new page structure (#54)
+
+### Refactor
+
+- **project**: migrate project to src layout (#49)
+
 ## v1.4.3 (2025-06-21)
 
 ### Fix

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,7 +116,7 @@ testpaths = ["tests"]
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "1.4.3"
+version = "1.4.4"
 version_files = [
     "src/novel_downloader/__init__.py"
 ]

--- a/src/novel_downloader/__init__.py
+++ b/src/novel_downloader/__init__.py
@@ -6,7 +6,7 @@ novel_downloader
 Core package for the Novel Downloader project.
 """
 
-__version__ = "1.4.3"
+__version__ = "1.4.4"
 
 __author__ = "Saudade Z"
 __email__ = "saudadez217@gmail.com"


### PR DESCRIPTION
### Description

Bump version from 1.4.3 to 1.4.4 for release.

---

### Changes

- Version bump only

---

### Type of change

- [x] Chore (release preparation)
