### PR TITLE
chore(ci): migrate PyPI publish to use pypa/gh-action-pypi-publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,8 +8,12 @@ on:
   workflow_dispatch:
 
 jobs:
-  deploy:
+  publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
     steps:
       - uses: actions/checkout@v3
 
@@ -31,8 +35,4 @@ jobs:
           python -m build
 
       - name: Publish to PyPI
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-        run: |
-          twine upload dist/*
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
### Description

This PR migrates PyPI publishing workflow to use GitHub’s OIDC-based "Trusted Publisher" mechanism and the official `pypa/gh-action-pypi-publish` action.

---

### Changes

- Add `permissions: id-token: write` to enable OIDC authentication
- Remove `TWINE_USERNAME`/`TWINE_PASSWORD` environment variables
- Replace manual `twine upload` step with `pypa/gh-action-pypi-publish@release/v1`

---

### Motivation

Using PyPI's Trusted Publisher (OIDC) flow:

- Eliminates the need to maintain a long-lived API token in Secrets
- Limits credentials scope to a short-lived, one-time use token
- Aligns with PyPA recommendations and PEP 740 attestations
- Simplifies the workflow by delegating publishing to an official action

---

### Type of change

- [x] Refactor (non-breaking change that improves structure or readability)
