### PR TITLE
feat(search): add BaseSearcher, site-specific searchers, CLI subcommand

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,6 +175,7 @@ cython_debug/
 
 # Settings
 examples/settings.toml
+chapter_data/
 debug/
 dev/
 downloads/

--- a/docs/4-supported-sites.md
+++ b/docs/4-supported-sites.md
@@ -8,15 +8,17 @@
 - **支持图片**: 是否支持抓取章节内插图并嵌入 EPUB 导出文件
 - **支持登录**: 部分站点提供书架或 VIP 阅读功能, 需账号登录
 
-| 站点名称                                                     | 站点标识符 | 支持分卷 | 支持图片 | 支持登录 |
-| ------------------------------------------------------------ | ---------- | -------- | -------- | -------- |
-| [起点中文网](https://www.qidian.com)                         | qidian     | ✅        | ❌        | ✅        |
-| [笔趣阁](http://www.b520.cc)                                 | biquge     | ❌        | ❌        | ❌        |
-| [铅笔小说](https://www.23qb.net), [备用](https://www.23qb.com/) | qianbi   | ✅        | ❌        | ❌        |
-| [SF轻小说](https://m.sfacg.com)                              | sfacg      | ✅        | ✅        | ✅        |
-| [ESJ Zone](https://www.esjzone.cc)                           | esjzone    | ✅        | ✅        | ✅        |
-| [百合会](https://www.yamibo.com/site/novel)                  | yamibo     | ✅        | ❌        | ✅        |
-| [哔哩轻小说](https://www.linovelib.com/)                     | linovelib   | ✅        | ✅        | ❌        |
+| 站点名称                                                     | 站点标识符 | 支持分卷 | 支持图片 | 支持登录 | 支持搜索 |
+| ------------------------------------------------------------ | ---------- | -------- | -------- | -------- | ---- |
+| [起点中文网](https://www.qidian.com)                         | qidian     | ✅        | ❌        | ✅        | ⚠️   |
+| [笔趣阁](http://www.b520.cc)                                 | biquge     | ❌        | ❌        | ❌        | ✅    |
+| [铅笔小说](https://www.23qb.net), [备用](https://www.23qb.com/) | qianbi   | ✅        | ❌        | ❌        | ✅    |
+| [SF轻小说](https://m.sfacg.com)                              | sfacg      | ✅        | ✅        | ✅        | ⚠️   |
+| [ESJ Zone](https://www.esjzone.cc)                           | esjzone    | ✅        | ✅        | ✅        | ✅    |
+| [百合会](https://www.yamibo.com/site/novel)                  | yamibo     | ✅        | ❌        | ✅        | ⚠️   |
+| [哔哩轻小说](https://www.linovelib.com/)                     | linovelib   | ✅        | ✅        | ❌        | ⚠️   |
+
+> ⚠️ 表示该功能尚未在本库中实现
 
 使用示例:
 
@@ -41,6 +43,9 @@ novel-cli download --site yamibo 123456
 
 # 下载 哔哩轻小说
 novel-cli download --site yamibo 1234
+
+# 根据关键词搜索
+novel-cli search 关键词
 ```
 
 ---

--- a/docs/6-cli-usage-examples.md
+++ b/docs/6-cli-usage-examples.md
@@ -103,7 +103,79 @@ novel-cli download
 
 ---
 
-### 5. config 子命令
+### 5. search 子命令
+
+按关键字搜索小说, 并根据用户选择开始下载:
+
+```bash
+novel-cli search [-h] [--site SITE] [--config CONFIG] [--limit N] [--site-limit M] keyword
+```
+
+**参数说明**:
+
+* `keyword`: 要搜索的关键字
+* `--site SITE`, `-s SITE`: 要搜索的站点键, 可多次指定, 默认搜索全部已支持站点
+* `--limit N`: 总体搜索结果数量上限, 默认为 `10`, 最小为 `1`
+* `--site-limit M`: 单站点搜索结果数量上限, 默认为 `5`, 最小为 `1`
+* `--config CONFIG`: 可选指定配置文件路径
+
+**示例**:
+
+```bash
+# 搜索所有站点 (默认全部)
+novel-cli search 三体
+
+# 指定单个站点 (如 biquge)
+novel-cli search --site biquge 三体
+
+# 搜索 biquge, 返回最多 5 条结果
+novel-cli search --site biquge --limit 5 三体
+
+# 总体返回最多 20 条, 每站点最多 5 条
+novel-cli search --limit 20 --site-limit 5 三体
+
+# 指定多个站点 (biquge 和 qianbi)
+novel-cli search -s biquge -s qianbi 三体
+```
+
+---
+
+### 6. export 子命令
+
+导出已下载的小说为指定格式的文件:
+
+```bash
+novel-cli export [OPTIONS] book_ids [book_ids ...]
+```
+
+**参数说明**:
+
+* `book_ids`: 要导出的一个或多个小说 ID
+* `--format`: 导出格式, 可选值为 `txt`, `epub`, `all`, 默认 `all`
+* `--site SITE`: 网站来源 (如 `biquge`, `qidian`), 默认 `qidian`
+* `--config CONFIG`: 可选指定配置文件路径
+
+**示例:**
+
+```bash
+# 导出为默认格式 (txt + epub)
+novel-cli export 12345 23456
+
+# 指定导出格式为 EPUB
+novel-cli export --format epub 88888
+
+# 指定站点来源并导出多本书
+novel-cli export --site biquge 12345 23456
+
+# 使用指定配置文件导出
+novel-cli export --config ./settings.toml 4321
+```
+
+> **注意**: 必须提供至少一个 `book_ids`
+
+---
+
+### 7. config 子命令
 
 用于初始化和管理下载器设置, 包括切换语言、设置 Cookie、更新规则等:
 
@@ -137,7 +209,7 @@ novel-cli config init --force
 
 ---
 
-### 6. clean 子命令
+### 8. clean 子命令
 
 清理下载器生成的本地缓存和全局配置文件:
 
@@ -172,42 +244,7 @@ novel-cli clean --all
 novel-cli clean --all --yes
 ```
 
-> **注意**: `--all` 会删除包括设置文件在内的所有本地数据, 请慎重使用！
-
----
-
-### 7. export 子命令
-
-导出已下载的小说为指定格式的文件:
-
-```bash
-novel-cli export [OPTIONS] book_ids [book_ids ...]
-```
-
-**参数说明**:
-
-* `book_ids`: 要导出的一个或多个小说 ID
-* `--format`: 导出格式, 可选值为 `txt`, `epub`, `all`, 默认 `all`
-* `--site SITE`: 网站来源 (如 `biquge`, `qidian`), 默认 `qidian`
-* `--config CONFIG`: 可选指定配置文件路径
-
-**示例:**
-
-```bash
-# 导出为默认格式 (txt + epub)
-novel-cli export 12345 23456
-
-# 指定导出格式为 EPUB
-novel-cli export --format epub 88888
-
-# 指定站点来源并导出多本书
-novel-cli export --site biquge 12345 23456
-
-# 使用指定配置文件导出
-novel-cli export --config ./settings.toml 4321
-```
-
-> **注意**: 必须提供至少一个 `book_ids`
+> **注意**: `--all` 会删除包括设置文件在内的所有本地数据, 请慎重使用!
 
 ---
 

--- a/docs/api/core/README.md
+++ b/docs/api/core/README.md
@@ -27,14 +27,34 @@
 * [**downloaders**](downloaders.md)
   将抓取、解析、导出整合, 符合 `DownloaderProtocol`
 
+* [**searchers**](searchers.md)
+  根据关键词搜索并返回结果
+
 ---
 
 ## 快速使用示例
 
 ```python
 from novel_downloader.core import (
-    get_fetcher, get_parser, get_exporter, get_downloader
+    get_fetcher, get_parser, get_exporter, get_downloader, search
 )
+
+async def _print_progress(done: int, total: int) -> None:
+    print(f"下载进度: {done}/{total} 章")
+
+keyword = "关键词"
+sites = ["biquge"]
+
+results = search(
+    keyword=keyword,
+    sites=sites,
+    limit=10,
+    per_site_limit=5,
+)
+
+chosen = results[0]  # 选择一个
+book_id = chosen["book_id"]  # 或不使用 search 直接定义
+site_key = chosen["site"]  # 了例如 "qidian"
 
 # 准备配置对象
 fetcher_cfg = FetcherConfig(...)
@@ -42,26 +62,26 @@ parser_cfg  = ParserConfig(...)
 exporter_cfg = ExporterConfig(...)
 downloader_cfg = DownloaderConfig(...)
 book_config = {
-    "book_id": 12345,
+    "book_id": book_id,
 }
 
 # 创建 Parser/Exporter
-parser   = get_parser("qidian", parser_cfg)
-exporter = get_exporter("qidian", exporter_cfg)
+parser   = get_parser(site_key, parser_cfg)
+exporter = get_exporter(site_key, exporter_cfg)
 
 # 异步上下文中创建并登录 Fetcher
-async with get_fetcher("qidian", fetcher_cfg) as fetcher:
+async with get_fetcher(site_key, fetcher_cfg) as fetcher:
     await fetcher.login(username, password)
 
     # 下载整本书
     downloader = get_downloader(
         fetcher,
         parser,
-        site="qidian",
+        site=site_key,
         config=downloader_cfg,
     )
-    await downloader.download(book_config, progress_hook=progress_hook)
+    await downloader.download(book_config, progress_hook=_print_progress)
 
 # 导出整本书
-exporter.export(book["book_id"])
+exporter.export(book_config["book_id"])
 ```

--- a/docs/api/core/searchers.md
+++ b/docs/api/core/searchers.md
@@ -1,0 +1,60 @@
+## Searchers
+
+### 目录
+
+- [Searchers](#searchers)
+  - [目录](#目录)
+  - [导入方式](#导入方式)
+  - [返回类型](#返回类型)
+
+---
+
+### 导入方式
+
+```python
+from novel_downloader.core.searchers import search
+```
+
+描述: 根据提供的关键词, 在指定站点或全部已配置站点中搜索小说, 并返回符合条件的结果列表
+
+参数:
+
+* `keyword`: 要搜索的关键字
+* `sites`: 要搜索的站点键列表, 可选
+* `limit`: 综合返回结果的最大数量, 默认为 `10`
+* `per_site_limit`: 每个站点返回结果的最大数量, 默认为 `5`
+
+示例:
+
+```python
+from novel_downloader.core.searchers import search
+
+# 在所有站点搜索 '三体', 最多返回 10 条结果
+results = search(
+    keyword="三体",
+)
+
+# 在 biquge 和 qianbi 站点搜索 '遮天'
+results = search(
+    keyword="遮天",
+    sites=["biquge", "qianbi"],
+    limit=20,
+    per_site_limit=5,
+)
+
+for item in results:
+    print(f"[{item['site']}] {item['title']} by {item['author']} (ID: {item['book_id']})")
+```
+
+### 返回类型
+
+```python
+class SearchResult(TypedDict, total=True):
+    site: str        # 站点键, 如 'biquge'
+    book_id: str     # 书籍在该站点中的唯一 ID
+    title: str       # 小说标题
+    author: str      # 作者
+    priority: int    # 检索优先级, 值越小优先级越高
+```
+
+函数返回 `list[SearchResult]`, 按 `priority` 升序排列

--- a/scripts/validate_i18n.py
+++ b/scripts/validate_i18n.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""
+validate_i18n.py
+
+A script to scan Python source files for `t(...)` i18n usages and verify that:
+  1. The translation key exists in the locale JSON files.
+  2. All named parameters used in the call appear as `{param}` placeholders.
+
+Usage:
+
+python scripts/validate_i18n.py -s src/novel_downloader -l src/novel_downloader/locales
+"""
+
+import argparse
+import ast
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def load_translations(locales_dir: Path) -> dict[str, dict[str, str]]:
+    """
+    Load all JSON translation files from the given directory.
+
+    :param locales_dir: Path to the directory containing locale JSON files.
+    :return: A dict mapping language code to its translations dict.
+    """
+    translations: dict[str, dict[str, str]] = {}
+    for locale_path in locales_dir.glob("*.json"):
+        lang = locale_path.stem
+        try:
+            with locale_path.open(encoding="utf-8") as f:
+                data = json.load(f)
+                if isinstance(data, dict):
+                    translations[lang] = data  # type: ignore
+        except Exception as e:
+            print(f"Warning: Failed to load {locale_path}: {e}", file=sys.stderr)
+    return translations
+
+
+def find_i18n_usages(source_path: Path) -> list[tuple[str, dict[str, str]]]:
+    """
+    Parse the file with AST, find all calls to t("key", foo="bar", ...)
+    and return a list of (key, {foo: "bar", ...}).
+    """
+    text = source_path.read_text(encoding="utf-8")
+    tree = ast.parse(text, filename=str(source_path))
+    usages: list[tuple[str, dict[str, str]]] = []
+
+    class Visitor(ast.NodeVisitor):
+        def visit_Call(self, node: ast.Call) -> Any:
+            if (
+                isinstance(node.func, ast.Name)
+                and node.func.id == "t"
+                and node.args
+                and isinstance(node.args[0], ast.Constant)
+                and isinstance(node.args[0].value, str)
+            ):
+                key = node.args[0].value
+                params: dict[str, str] = {}
+                for kw in node.keywords:
+                    if (
+                        kw.arg is not None
+                        and isinstance(kw.value, ast.Constant)
+                        and isinstance(kw.value.value, str)
+                    ):
+                        params[kw.arg] = kw.value.value
+                usages.append((key, params))
+
+            self.generic_visit(node)
+
+    Visitor().visit(tree)
+    return usages
+
+
+def validate_usage(
+    lang: str,
+    key: str,
+    params: dict[str, str],
+    translations: dict[str, str],
+    source_path: Path,
+) -> bool:
+    """
+    Verify that the key exists and that all params appear as placeholders.
+
+    :param lang: The locale code being validated (e.g. "en", "zh").
+    :param key: The translation key.
+    :param params: Dict of named parameters used in the call.
+    :param translations: The dict of translations for this language.
+    :param source_path: The file where this usage was found (for error reporting).
+    :return: True if valid, False otherwise.
+    """
+    ok = True
+    if key not in translations:
+        print(f"[MISSING KEY] {source_path} ({lang}): key '{key}' not found")
+        ok = False
+    else:
+        template = translations[key]
+        for name in params:
+            placeholder = "{" + name + "}"
+            if placeholder not in template:
+                print(
+                    f"[MISSING PLACEHOLDER] {source_path} ({lang}): "
+                    f"key '{key}' missing placeholder {placeholder}"
+                )
+                ok = False
+    return ok
+
+
+def process_file(
+    source_path: Path,
+    all_translations: dict[str, dict[str, str]],
+) -> bool:
+    """
+    Process a single Python source file:
+      - Skip if it does not import the t() function.
+      - Find all t(...) usages via AST.
+      - Validate each usage against every loaded locale.
+
+    :param source_path: Path to the .py file.
+    :param all_translations: Mapping of lang -> translations dict.
+    :return: True if all usages are valid in all locales, False otherwise.
+    """
+    content = source_path.read_text(encoding="utf-8")
+    # Quick check: skip files that don't import t
+    if "import t" not in content:
+        return True
+
+    usages = find_i18n_usages(source_path)
+    file_ok = True
+    for lang, translations in all_translations.items():
+        for key, params in usages:
+            if not validate_usage(lang, key, params, translations, source_path):
+                file_ok = False
+    return file_ok
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate i18n translation keys and placeholders."
+    )
+    parser.add_argument(
+        "--src",
+        "-s",
+        type=Path,
+        default=Path("."),
+        help="Path to the root of the Python source tree to scan.",
+    )
+    parser.add_argument(
+        "--locales",
+        "-l",
+        dest="locales_dir",
+        type=Path,
+        default=Path("locales"),
+        help="Path to the directory containing locale JSON files.",
+    )
+    args = parser.parse_args()
+
+    if not args.src.is_dir():
+        print(f"Error: --src '{args.src}' is not a directory.", file=sys.stderr)
+        return 1
+    if not args.locales_dir.is_dir():
+        print(
+            f"Error: --locales '{args.locales_dir}' is not a directory.",
+            file=sys.stderr,
+        )
+        return 1
+
+    translations = load_translations(args.locales_dir)
+    if not translations:
+        print(
+            f"Error: No translation files found in {args.locales_dir}", file=sys.stderr
+        )
+        return 1
+
+    all_ok = True
+    for py_file in args.src.rglob("*.py"):
+        if not process_file(py_file, translations):
+            all_ok = False
+
+    if all_ok:
+        print("All i18n checks passed.")
+        return 0
+    else:
+        print("i18n checks failed. See messages above.", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/novel_downloader/cli/main.py
+++ b/src/novel_downloader/cli/main.py
@@ -14,6 +14,7 @@ from .clean import register_clean_subcommand
 from .config import register_config_subcommand
 from .download import register_download_subcommand
 from .export import register_export_subcommand
+from .search import register_search_subcommand
 
 
 def cli_main() -> None:
@@ -24,6 +25,7 @@ def cli_main() -> None:
     register_config_subcommand(subparsers)
     register_download_subcommand(subparsers)
     register_export_subcommand(subparsers)
+    register_search_subcommand(subparsers)
 
     args = parser.parse_args()
     if hasattr(args, "func"):

--- a/src/novel_downloader/cli/search.py
+++ b/src/novel_downloader/cli/search.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""
+novel_downloader.cli.search
+---------------------------
+
+"""
+
+import asyncio
+from argparse import Namespace, _SubParsersAction
+from collections.abc import Sequence
+from pathlib import Path
+
+from novel_downloader.cli.download import _download
+from novel_downloader.config import ConfigAdapter, load_config
+from novel_downloader.core import search
+from novel_downloader.models import BookConfig, SearchResult
+from novel_downloader.utils.i18n import t
+
+
+def register_search_subcommand(subparsers: _SubParsersAction) -> None:  # type: ignore
+    parser = subparsers.add_parser("search", help=t("help_search"))
+
+    parser.add_argument(
+        "--site",
+        "-s",
+        action="append",
+        metavar="SITE",
+        help=t("help_search_sites"),
+    )
+    parser.add_argument(
+        "keyword",
+        help=t("help_search_keyword"),
+    )
+    parser.add_argument(
+        "--config",
+        type=str,
+        help=t("help_config"),
+    )
+
+    parser.set_defaults(func=handle_search)
+
+
+def handle_search(args: Namespace) -> None:
+    """
+    Handler for the `search` subcommand. Loads config, runs the search,
+    prompts the user to pick one result, then kicks off download.
+    """
+    sites: Sequence[str] | None = args.site or None
+    keyword: str = args.keyword
+    config_path: Path | None = Path(args.config) if args.config else None
+
+    try:
+        config_data = load_config(config_path)
+    except Exception as e:
+        print(t("download_config_load_fail", err=str(e)))
+        return
+
+    results = search(
+        keyword=keyword,
+        sites=sites,
+        limit=10,
+    )
+
+    chosen = _prompt_user_select(results)
+    if chosen is None:
+        # user cancelled or no valid choice
+        return
+
+    adapter = ConfigAdapter(config=config_data, site=chosen["site"])
+    books: list[BookConfig] = [{"book_id": chosen["book_id"]}]
+    asyncio.run(_download(adapter, chosen["site"], books))
+
+
+def _prompt_user_select(
+    results: Sequence[SearchResult],
+    max_attempts: int = 3,
+) -> SearchResult | None:
+    """
+    Display a numbered list of results and prompt the user to pick one.
+
+    :param results:      A list of SearchResult dicts.
+    :param max_attempts: How many bad inputs to tolerate before giving up.
+    :return:             The chosen SearchResult, or None if cancelled/failed.
+    """
+    if not results:
+        print(t("no_results"))
+        return None
+
+    # Show choices
+    for i, r in enumerate(results, start=1):
+        print(f"[{i}] {r['title']} - {r['author']} ({r['site']})")
+
+    attempts = 0
+    while attempts < max_attempts:
+        choice = input(t("prompt_select_index")).strip()
+        if choice == "":
+            return None
+        if choice.isdigit():
+            idx = int(choice)
+            if 1 <= idx <= len(results):
+                return results[idx - 1]
+        print(t("invalid_selection"))
+        attempts += 1
+
+    return None

--- a/src/novel_downloader/cli/search.py
+++ b/src/novel_downloader/cli/search.py
@@ -36,6 +36,21 @@ def register_search_subcommand(subparsers: _SubParsersAction) -> None:  # type: 
         type=str,
         help=t("help_config"),
     )
+    parser.add_argument(
+        "--limit",
+        "-l",
+        type=int,
+        default=10,
+        metavar="N",
+        help=t("help_search_limit"),
+    )
+    parser.add_argument(
+        "--site-limit",
+        type=int,
+        default=5,
+        metavar="M",
+        help=t("help_search_site_limit"),
+    )
 
     parser.set_defaults(func=handle_search)
 
@@ -47,6 +62,8 @@ def handle_search(args: Namespace) -> None:
     """
     sites: Sequence[str] | None = args.site or None
     keyword: str = args.keyword
+    overall_limit = max(1, args.limit)
+    per_site_limit = max(1, args.site_limit)
     config_path: Path | None = Path(args.config) if args.config else None
 
     try:
@@ -58,7 +75,8 @@ def handle_search(args: Namespace) -> None:
     results = search(
         keyword=keyword,
         sites=sites,
-        limit=10,
+        limit=overall_limit,
+        per_site_limit=per_site_limit,
     )
 
     chosen = _prompt_user_select(results)
@@ -88,7 +106,7 @@ def _prompt_user_select(
 
     # Show choices
     for i, r in enumerate(results, start=1):
-        print(f"[{i}] {r['title']} - {r['author']} ({r['site']})")
+        print(f"[{i}] {r['title']} - {r['author']} ({r['site']}, id: {r['book_id']})")
 
     attempts = 0
     while attempts < max_attempts:

--- a/src/novel_downloader/core/__init__.py
+++ b/src/novel_downloader/core/__init__.py
@@ -19,6 +19,7 @@ __all__ = [
     "get_exporter",
     "get_fetcher",
     "get_parser",
+    "search",
     "DownloaderProtocol",
     "ExporterProtocol",
     "FetcherProtocol",
@@ -35,3 +36,4 @@ from .interfaces import (
     ParserProtocol,
 )
 from .parsers import get_parser
+from .searchers import search

--- a/src/novel_downloader/core/fetchers/base/session.py
+++ b/src/novel_downloader/core/fetchers/base/session.py
@@ -158,7 +158,12 @@ class BaseSession(FetcherProtocol, abc.ABC):
             await self._session.close()
         self._session = None
 
-    async def fetch(self, url: str, **kwargs: Any) -> str:
+    async def fetch(
+        self,
+        url: str,
+        encoding: str | None = None,
+        **kwargs: Any,
+    ) -> str:
         """
         Fetch the content from the given URL asynchronously, with retry support.
 
@@ -174,8 +179,7 @@ class BaseSession(FetcherProtocol, abc.ABC):
             try:
                 async with self.session.get(url, **kwargs) as resp:
                     resp.raise_for_status()
-                    text: str = await resp.text()
-                    return text
+                    return await self._response_to_str(resp, encoding)
             except aiohttp.ClientError:
                 if attempt < self.retry_times:
                     await async_sleep_with_random_delay(
@@ -406,6 +410,25 @@ class BaseSession(FetcherProtocol, abc.ABC):
         if self._session:
             return dict(self._session.headers)
         return self._headers.copy()
+
+    @staticmethod
+    async def _response_to_str(
+        resp: ClientResponse,
+        encoding: str | None = None,
+    ) -> str:
+        """
+        Read the full body of resp as text. First try the declared charset,
+        then on UnicodeDecodeError fall back to a lenient utf-8 decode.
+        """
+        data: bytes = await resp.read()
+        encodings = [encoding, resp.charset, "utf-8", "gb18030", "gbk"]
+        encodings_list: list[str] = [e for e in encodings if e]
+        for enc in encodings_list:
+            try:
+                return data.decode(enc)
+            except UnicodeDecodeError:
+                continue
+        return data.decode("utf-8", errors="ignore")
 
     async def __aenter__(self) -> Self:
         if self._session is None or self._session.closed:

--- a/src/novel_downloader/core/fetchers/biquge/session.py
+++ b/src/novel_downloader/core/fetchers/biquge/session.py
@@ -60,7 +60,7 @@ class BiqugeSession(BaseSession):
         :return: The chapter content as a string.
         """
         url = self.chapter_url(book_id=book_id, chapter_id=chapter_id)
-        return [await self.fetch(url, **kwargs)]
+        return [await self.fetch(url, encoding="gbk", **kwargs)]
 
     @classmethod
     def book_info_url(cls, book_id: str) -> str:

--- a/src/novel_downloader/core/fetchers/qidian/session.py
+++ b/src/novel_downloader/core/fetchers/qidian/session.py
@@ -151,6 +151,7 @@ class QidianSession(BaseSession):
     async def fetch(
         self,
         url: str,
+        encoding: str | None = None,
         **kwargs: Any,
     ) -> str:
         """
@@ -174,7 +175,7 @@ class QidianSession(BaseSession):
 
                 async with self.session.get(url, **kwargs) as resp:
                     resp.raise_for_status()
-                    text: str = await resp.text()
+                    text: str = await resp.text(encoding=encoding)
                     return text
             except aiohttp.ClientError:
                 if attempt < self.retry_times:

--- a/src/novel_downloader/core/interfaces/__init__.py
+++ b/src/novel_downloader/core/interfaces/__init__.py
@@ -19,9 +19,11 @@ __all__ = [
     "ExporterProtocol",
     "FetcherProtocol",
     "ParserProtocol",
+    "SearcherProtocol",
 ]
 
 from .downloader import DownloaderProtocol
 from .exporter import ExporterProtocol
 from .fetcher import FetcherProtocol
 from .parser import ParserProtocol
+from .searcher import SearcherProtocol

--- a/src/novel_downloader/core/interfaces/searcher.py
+++ b/src/novel_downloader/core/interfaces/searcher.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+"""
+novel_downloader.core.interfaces.searcher
+-----------------------------------------
+
+"""
+
+from typing import Protocol
+
+from novel_downloader.models import SearchResult
+
+
+class SearcherProtocol(Protocol):
+    site_name: str
+
+    @classmethod
+    def search(cls, keyword: str, limit: int | None = None) -> list[SearchResult]:
+        ...

--- a/src/novel_downloader/core/searchers/__init__.py
+++ b/src/novel_downloader/core/searchers/__init__.py
@@ -7,8 +7,14 @@ novel_downloader.core.searchers
 
 __all__ = [
     "search",
+    "BiqugeSearcher",
+    "EsjzoneSearcher",
+    "QianbiSearcher",
     "QidianSearcher",
 ]
 
+from .biquge import BiqugeSearcher
+from .esjzone import EsjzoneSearcher
+from .qianbi import QianbiSearcher
 from .qidian import QidianSearcher
 from .registry import search

--- a/src/novel_downloader/core/searchers/__init__.py
+++ b/src/novel_downloader/core/searchers/__init__.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+"""
+novel_downloader.core.searchers
+-------------------------------
+
+"""

--- a/src/novel_downloader/core/searchers/__init__.py
+++ b/src/novel_downloader/core/searchers/__init__.py
@@ -4,3 +4,11 @@ novel_downloader.core.searchers
 -------------------------------
 
 """
+
+__all__ = [
+    "search",
+    "QidianSearcher",
+]
+
+from .qidian import QidianSearcher
+from .registry import search

--- a/src/novel_downloader/core/searchers/base.py
+++ b/src/novel_downloader/core/searchers/base.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
-novel_downloader.core.base
---------------------------
+novel_downloader.core.searchers.base
+------------------------------------
 
 """
 

--- a/src/novel_downloader/core/searchers/base.py
+++ b/src/novel_downloader/core/searchers/base.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""
+novel_downloader.core.base
+--------------------------
+
+"""
+
+import abc
+from typing import Any
+from urllib.parse import quote_plus
+
+import requests
+
+from novel_downloader.core.interfaces import SearcherProtocol
+from novel_downloader.models import SearchResult
+from novel_downloader.utils.constants import DEFAULT_USER_HEADERS
+
+
+class BaseSearcher(abc.ABC, SearcherProtocol):
+    site_name: str
+    _session = requests.Session()
+    _DEFAULT_TIMEOUT: tuple[int, int] = (5, 10)
+
+    @classmethod
+    def search(cls, keyword: str, limit: int | None = None) -> list[SearchResult]:
+        html = cls._fetch_html(keyword)
+        return cls._parse_html(html, limit)
+
+    @classmethod
+    @abc.abstractmethod
+    def _fetch_html(cls, keyword: str) -> str:
+        """Get raw HTML from search API or page"""
+        pass
+
+    @classmethod
+    @abc.abstractmethod
+    def _parse_html(cls, html_str: str, limit: int | None = None) -> list[SearchResult]:
+        """Parse HTML into standard search result list"""
+        pass
+
+    @classmethod
+    def _http_get(
+        cls,
+        url: str,
+        *,
+        params: dict[str, str] | None = None,
+        headers: dict[str, str] | None = None,
+        timeout: tuple[int, int] | None = None,
+        **kwargs: Any,
+    ) -> requests.Response:
+        """
+        Helper for GET requests with default headers, timeout, and error-raising.
+        """
+        hdrs = {**DEFAULT_USER_HEADERS, **(headers or {})}
+        resp = cls._session.get(
+            url,
+            params=params,
+            headers=hdrs,
+            timeout=timeout or cls._DEFAULT_TIMEOUT,
+            **kwargs,
+        )
+        resp.raise_for_status()
+        return resp
+
+    @classmethod
+    def _http_post(
+        cls,
+        url: str,
+        *,
+        data: dict[str, str] | str | None = None,
+        headers: dict[str, str] | None = None,
+        timeout: tuple[int, int] | None = None,
+        **kwargs: Any,
+    ) -> requests.Response:
+        """
+        Helper for POST requests with default headers, timeout, and error-raising.
+        """
+        hdrs = {**DEFAULT_USER_HEADERS, **(headers or {})}
+        resp = cls._session.post(
+            url,
+            data=data,
+            headers=hdrs,
+            timeout=timeout or cls._DEFAULT_TIMEOUT,
+            **kwargs,
+        )
+        resp.raise_for_status()
+        return resp
+
+    @staticmethod
+    def _quote(q: str) -> str:
+        """URL-encode a query string safely."""
+        return quote_plus(q)

--- a/src/novel_downloader/core/searchers/biquge.py
+++ b/src/novel_downloader/core/searchers/biquge.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-novel_downloader.core.searchers.qidian
+novel_downloader.core.searchers.biquge
 --------------------------------------
 
 """
@@ -17,30 +17,30 @@ logger = logging.getLogger(__name__)
 
 
 @register_searcher(
-    site_keys=["qidian", "qd"],
+    site_keys=["biquge", "bqg"],
 )
-class QidianSearcher(BaseSearcher):
-    site_name = "qidian"
-    priority = 0
-    SEARCH_URL = "https://www.qidian.com/so/{query}.html"
+class BiqugeSearcher(BaseSearcher):
+    site_name = "biquge"
+    priority = 5
+    SEARCH_URL = "http://www.b520.cc/modules/article/search.php"
 
     @classmethod
     def _fetch_html(cls, keyword: str) -> str:
         """
-        Fetch raw HTML from Qidian's search page.
+        Fetch raw HTML from Biquge's search page.
 
-        :param keyword: The search term to query on Qidian.
+        :param keyword: The search term to query on Biquge.
         :return: HTML text of the search results page, or an empty string on fail.
         """
-        url = cls.SEARCH_URL.format(query=cls._quote(keyword))
+        params = {"searchkey": keyword}
         try:
-            response = cls._http_get(url)
+            response = cls._http_get(cls.SEARCH_URL, params=params)
             return response.text
         except Exception:
             logger.error(
                 "Failed to fetch HTML for keyword '%s' from '%s'",
                 keyword,
-                url,
+                cls.SEARCH_URL,
                 exc_info=True,
             )
             return ""
@@ -48,30 +48,29 @@ class QidianSearcher(BaseSearcher):
     @classmethod
     def _parse_html(cls, html_str: str, limit: int | None = None) -> list[SearchResult]:
         """
-        Parse raw HTML from Qidian search results into list of SearchResult.
+        Parse raw HTML from Biquge search results into list of SearchResult.
 
-        :param html: Raw HTML string from Qidian search results page.
+        :param html_str: Raw HTML string from Biquge search results page.
         :param limit: Maximum number of results to return, or None for all.
         :return: List of SearchResult dicts.
         """
         doc = html.fromstring(html_str)
-        items = doc.xpath(
-            '//div[@id="result-list"]//li[contains(@class, "res-book-item")]'
-        )
+        rows = doc.xpath('//table[@class="grid"]//tr[position()>1]')
         results: list[SearchResult] = []
 
-        base_prio = getattr(cls, "priority", 0)
-        for idx, item in enumerate(items):
+        for idx, row in enumerate(rows):
             if limit is not None and idx >= limit:
                 break
-            book_id = item.get("data-bid")
-            title_elem = item.xpath('.//h3[@class="book-info-title"]/a')[0]
+            # Title and book_id
+            title_elem = row.xpath(".//td[1]/a")[0]
             title = title_elem.text_content().strip()
-            author_nodes = item.xpath(
-                './/p[@class="author"]/a[@class="name"] | .//p[@class="author"]/i'
-            )
-            author = author_nodes[0].text_content().strip() if author_nodes else ""
-            prio = base_prio + idx
+            href = title_elem.get("href", "").strip("/")
+            book_id = href.split("/")[0] if href else ""
+            # Author
+            author = row.xpath(".//td[3]")[0].text_content().strip()
+            # Compute priority
+            prio = cls.priority + idx
+
             results.append(
                 SearchResult(
                     site=cls.site_name,

--- a/src/novel_downloader/core/searchers/qianbi.py
+++ b/src/novel_downloader/core/searchers/qianbi.py
@@ -6,6 +6,7 @@ novel_downloader.core.searchers.qianbi
 """
 
 import logging
+import re
 
 from lxml import html
 
@@ -53,6 +54,53 @@ class QianbiSearcher(BaseSearcher):
         :param html_str: Raw HTML string from Qianbi search results page.
         :param limit: Maximum number of results to return, or None for all.
         :return: List of SearchResult dicts.
+        """
+        if html_str.find('<meta property="og:url"') != -1:
+            return cls._parse_detail_html(html_str)
+        return cls._parse_search_list_html(html_str, limit)
+
+    @classmethod
+    def _parse_detail_html(cls, html_str: str) -> list[SearchResult]:
+        """
+        Parse a single-book detail page, detected via <meta property="og:url">.
+
+        :param html_str: Raw HTML of the book detail page.
+        :return: A single-element list with the book's SearchResult.
+        """
+        doc = html.fromstring(html_str)
+        url = doc.xpath('//meta[@property="og:url"]/@content')
+        if not url:
+            return []
+
+        # extract book_id via regex
+        m = re.search(r"/book/(\d+)/", url[0])
+        book_id = m.group(1) if m else ""
+        # title from <h1 class="page-title">
+        title = (doc.xpath('//h1[@class="page-title"]/text()') or [""])[0].strip()
+        author = (doc.xpath('//a[contains(@href,"/author/")]/@title') or [""])[
+            0
+        ].strip()
+
+        return [
+            SearchResult(
+                site=cls.site_name,
+                book_id=book_id,
+                title=title,
+                author=author,
+                priority=cls.priority,
+            )
+        ]
+
+    @classmethod
+    def _parse_search_list_html(
+        cls, html_str: str, limit: int | None
+    ) -> list[SearchResult]:
+        """
+        Parse a multi-item search result page.
+
+        :param html_str: Raw HTML of the search-results page.
+        :param limit:    Maximum number of items to return, or None for all.
+        :return:         List of SearchResult.
         """
         doc = html.fromstring(html_str)
         items = doc.xpath('//div[contains(@class,"module-search-item")]')

--- a/src/novel_downloader/core/searchers/qianbi.py
+++ b/src/novel_downloader/core/searchers/qianbi.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""
+novel_downloader.core.searchers.qianbi
+-----------------------------------------
+
+"""
+
+import logging
+
+from lxml import html
+
+from novel_downloader.core.searchers.base import BaseSearcher
+from novel_downloader.core.searchers.registry import register_searcher
+from novel_downloader.models import SearchResult
+
+logger = logging.getLogger(__name__)
+
+
+@register_searcher(
+    site_keys=["qianbi"],
+)
+class QianbiSearcher(BaseSearcher):
+    site_name = "qianbi"
+    priority = 3
+    SEARCH_URL = "https://www.23qb.com/search.html"
+
+    @classmethod
+    def _fetch_html(cls, keyword: str) -> str:
+        """
+        Fetch raw HTML from Qianbi's search page.
+
+        :param keyword: The search term to query on Qianbi.
+        :return: HTML text of the search results page, or an empty string on fail.
+        """
+        params = {"searchkey": keyword}
+        try:
+            response = cls._http_get(cls.SEARCH_URL, params=params)
+            return response.text
+        except Exception:
+            logger.error(
+                "Failed to fetch HTML for keyword '%s' from '%s'",
+                keyword,
+                cls.SEARCH_URL,
+                exc_info=True,
+            )
+            return ""
+
+    @classmethod
+    def _parse_html(cls, html_str: str, limit: int | None = None) -> list[SearchResult]:
+        """
+        Parse raw HTML from Qianbi search results into list of SearchResult.
+
+        :param html_str: Raw HTML string from Qianbi search results page.
+        :param limit: Maximum number of results to return, or None for all.
+        :return: List of SearchResult dicts.
+        """
+        doc = html.fromstring(html_str)
+        items = doc.xpath('//div[contains(@class,"module-search-item")]')
+        results: list[SearchResult] = []
+
+        for idx, item in enumerate(items):
+            if limit is not None and idx >= limit:
+                break
+            # Title and book_id
+            link = item.xpath('.//div[@class="novel-info-header"]/h3/a')[0]
+            title = link.text_content().strip()
+            href = link.get("href", "").strip("/")
+            book_id = href.replace("book/", "").strip("/")
+            # Author is not present on the page
+            author = ""
+            # Compute priority
+            prio = cls.priority + idx
+
+            results.append(
+                SearchResult(
+                    site=cls.site_name,
+                    book_id=book_id,
+                    title=title,
+                    author=author,
+                    priority=prio,
+                )
+            )
+        return results

--- a/src/novel_downloader/core/searchers/qidian.py
+++ b/src/novel_downloader/core/searchers/qidian.py
@@ -10,16 +10,19 @@ import logging
 from lxml import html
 
 from novel_downloader.core.searchers.base import BaseSearcher
-from novel_downloader.core.searchers.registry import register_searcher
 from novel_downloader.models import SearchResult
 
 logger = logging.getLogger(__name__)
 
 
-@register_searcher(
-    site_keys=["qidian", "qd"],
-)
+# @register_searcher(
+#     site_keys=["qidian", "qd"],
+# )
 class QidianSearcher(BaseSearcher):
+    """
+    TODO: 现在默认没有 cookie 会跳转
+    """
+
     site_name = "qidian"
     priority = 0
     SEARCH_URL = "https://www.qidian.com/so/{query}.html"

--- a/src/novel_downloader/core/searchers/qidian.py
+++ b/src/novel_downloader/core/searchers/qidian.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""
+novel_downloader.core.searchers.qidian
+--------------------------------------
+
+"""
+
+import logging
+
+from lxml import html
+
+from novel_downloader.core.searchers.base import BaseSearcher
+from novel_downloader.core.searchers.registry import register_searcher
+from novel_downloader.models import SearchResult
+
+logger = logging.getLogger(__name__)
+
+
+@register_searcher(
+    site_keys=["qidian", "qd"],
+)
+class QidianSearcher(BaseSearcher):
+    site_name = "qidian"
+    priority = 0
+    SEARCH_URL = "https://www.qidian.com/so/{query}.html"
+
+    @classmethod
+    def _fetch_html(cls, keyword: str) -> str:
+        """
+        Fetch raw HTML from Qidian's search page.
+
+        :param keyword: The search term to query on Qidian.
+        :return: HTML text of the search results page, or an empty string on fail.
+        """
+        url = cls.SEARCH_URL.format(query=cls._quote(keyword))
+        try:
+            response = cls._http_get(url)
+            return response.text
+        except Exception:
+            logger.error(
+                "Failed to fetch HTML for keyword '%s' from '%s'",
+                keyword,
+                url,
+                exc_info=True,
+            )
+            return ""
+
+    @classmethod
+    def _parse_html(cls, html_str: str, limit: int | None = None) -> list[SearchResult]:
+        """
+        Parse raw HTML from Qidian search results into list of SearchResult.
+
+        :param html: Raw HTML string from Qidian search results page.
+        :param limit: Maximum number of results to return, or None for all.
+        :return: List of SearchResult dicts.
+        """
+        doc = html.fromstring(html_str)
+        items = doc.xpath(
+            '//div[@id="result-list"]//li[contains(@class, "res-book-item")]'
+        )
+        results: list[SearchResult] = []
+
+        base_prio = getattr(cls, "priority", 0)
+        for idx, item in enumerate(items):
+            if limit is not None and idx >= limit:
+                break
+            book_id = item.get("data-bid")
+            title_elem = item.xpath('.//h3[@class="book-info-title"]/a')[0]
+            title = title_elem.text_content().strip()
+            author_nodes = item.xpath(
+                './/p[@class="author"]/a[@class="name"] | .//p[@class="author"]/i'
+            )
+            author = author_nodes[0].text_content().strip() if author_nodes else ""
+            prio = base_prio + idx
+            results.append(
+                {
+                    "site": cls.site_name,
+                    "book_id": book_id,
+                    "title": title,
+                    "author": author,
+                    "priority": prio,
+                }
+            )
+        return results

--- a/src/novel_downloader/core/searchers/registry.py
+++ b/src/novel_downloader/core/searchers/registry.py
@@ -34,7 +34,7 @@ def register_searcher(
 
 
 def search(
-    name: str,
+    keyword: str,
     sites: Sequence[str] | None = None,
     limit: int | None = None,
 ) -> list[SearchResult]:
@@ -42,23 +42,20 @@ def search(
     Perform a search for the given keyword across one or more registered sites,
     then aggregate and sort the results by their `priority` value.
 
-    :param name:  The search term or keyword to query.
-    :param sites: An optional sequence of site keys to limit which searchers.
-    :param limit: Maximum total number of results to return; if None, return all.
-    :return:      A flat list of `SearchResult` objects.
+    :param keyword: The search term or keyword to query.
+    :param sites:   An optional sequence of site keys to limit which searchers.
+    :param limit:   Maximum total number of results to return; if None, return all.
+    :return:        A flat list of `SearchResult` objects.
     """
     keys = list(sites or _SEARCHER_REGISTRY.keys())
+    to_call = {_SEARCHER_REGISTRY[key] for key in keys if key in _SEARCHER_REGISTRY}
 
     results: list[SearchResult] = []
-
-    for key in keys:
-        cls = _SEARCHER_REGISTRY[key]
+    for cls in to_call:
         try:
-            results.extend(cls.search(name))
+            results.extend(cls.search(keyword, limit=3))
         except Exception:
             continue
 
     results.sort(key=lambda res: res["priority"])
-    if limit is not None:
-        return results[:limit]
-    return results
+    return results[:limit] if limit is not None else results

--- a/src/novel_downloader/core/searchers/registry.py
+++ b/src/novel_downloader/core/searchers/registry.py
@@ -37,6 +37,7 @@ def search(
     keyword: str,
     sites: Sequence[str] | None = None,
     limit: int | None = None,
+    per_site_limit: int = 5,
 ) -> list[SearchResult]:
     """
     Perform a search for the given keyword across one or more registered sites,
@@ -45,6 +46,7 @@ def search(
     :param keyword: The search term or keyword to query.
     :param sites:   An optional sequence of site keys to limit which searchers.
     :param limit:   Maximum total number of results to return; if None, return all.
+    :param per_site_limit: Maximum number of search results per site.
     :return:        A flat list of `SearchResult` objects.
     """
     keys = list(sites or _SEARCHER_REGISTRY.keys())
@@ -53,7 +55,7 @@ def search(
     results: list[SearchResult] = []
     for cls in to_call:
         try:
-            results.extend(cls.search(keyword, limit=3))
+            results.extend(cls.search(keyword, limit=per_site_limit))
         except Exception:
             continue
 

--- a/src/novel_downloader/core/searchers/registry.py
+++ b/src/novel_downloader/core/searchers/registry.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""
+novel_downloader.core.searchers.registry
+----------------------------------------
+
+"""
+
+__all__ = ["register_searcher", "search"]
+
+from collections.abc import Callable, Sequence
+from typing import TypeVar
+
+from novel_downloader.core.searchers.base import BaseSearcher
+from novel_downloader.models import SearchResult
+
+S = TypeVar("S", bound=BaseSearcher)
+
+_SEARCHER_REGISTRY: dict[str, type[BaseSearcher]] = {}
+
+
+def register_searcher(
+    site_keys: Sequence[str],
+) -> Callable[[type[S]], type[S]]:
+    """
+    Decorator to register a searcher class under given name.
+    """
+
+    def decorator(cls: type[S]) -> type[S]:
+        for key in site_keys:
+            _SEARCHER_REGISTRY[key] = cls
+        return cls
+
+    return decorator
+
+
+def search(
+    name: str,
+    sites: Sequence[str] | None = None,
+    limit: int | None = None,
+) -> list[SearchResult]:
+    """
+    Perform a search for the given keyword across one or more registered sites,
+    then aggregate and sort the results by their `priority` value.
+
+    :param name:  The search term or keyword to query.
+    :param sites: An optional sequence of site keys to limit which searchers.
+    :param limit: Maximum total number of results to return; if None, return all.
+    :return:      A flat list of `SearchResult` objects.
+    """
+    keys = list(sites or _SEARCHER_REGISTRY.keys())
+
+    results: list[SearchResult] = []
+
+    for key in keys:
+        cls = _SEARCHER_REGISTRY[key]
+        try:
+            results.extend(cls.search(name))
+        except Exception:
+            continue
+
+    results.sort(key=lambda res: res["priority"])
+    if limit is not None:
+        return results[:limit]
+    return results

--- a/src/novel_downloader/locales/en.json
+++ b/src/novel_downloader/locales/en.json
@@ -63,6 +63,7 @@
   "download_edit_config": "Please edit your config and replace them with real book IDs.",
   "download_downloading": "Downloading book {book_id} from {site}...",
   "download_prompt_parse": "Parse...",
+  "download_login_failed": "Download login failed: please check your cookies or account credentials and try again.",
   "download_book_ids": "One or more book IDs to process",
   "download_option_start": "Start chapter ID (applies to the first book ID only)",
   "download_option_end": "End chapter ID (applies to the first book ID only)",
@@ -117,6 +118,8 @@
   "help_search": "search for a book on one or more sites",
   "help_search_sites": "which site keys to search (default: all)",
   "help_search_keyword": "keyword to look for",
+  "help_search_limit": "Maximum number of search results",
+  "help_search_site_limit":  "Maximum number of search results per site",
   "no_results": "No results found.",
   "prompt_select_index": "Select a result by number (or press Enter to cancel): ",
   "invalid_selection": "Invalid choice, please try again."

--- a/src/novel_downloader/locales/en.json
+++ b/src/novel_downloader/locales/en.json
@@ -58,6 +58,7 @@
   "download_site_mode": "Mode: {mode}",
   "download_no_ids": "No book IDs provided. Exiting.",
   "download_fail_get_ids": "Failed to get book IDs from config: {err}",
+  "download_config_load_fail": "Failed to load config: {err}",
   "download_only_example": "Only example book IDs found (e.g. '{example}').",
   "download_edit_config": "Please edit your config and replace them with real book IDs.",
   "download_downloading": "Downloading book {book_id} from {site}...",
@@ -111,5 +112,12 @@
   "export_success_txt": "Successfully exported {book_id} as TXT.",
   "export_failed_txt": "Failed to export {book_id} as TXT: {err}",
   "export_success_epub": "Successfully exported {book_id} as EPUB.",
-  "export_failed_epub": "Failed to export {book_id} as EPUB: {err}"
+  "export_failed_epub": "Failed to export {book_id} as EPUB: {err}",
+
+  "help_search": "search for a book on one or more sites",
+  "help_search_sites": "which site keys to search (default: all)",
+  "help_search_keyword": "keyword to look for",
+  "no_results": "No results found.",
+  "prompt_select_index": "Select a result by number (or press Enter to cancel): ",
+  "invalid_selection": "Invalid choice, please try again."
 }

--- a/src/novel_downloader/locales/zh.json
+++ b/src/novel_downloader/locales/zh.json
@@ -62,6 +62,7 @@
   "download_only_example": "只发现示例书籍 ID (例如 '{example}')",
   "download_edit_config": "请编辑配置并将示例 ID 替换为真实书籍 ID",
   "download_downloading": "正在从 {site} 下载书籍 {book_id}...",
+  "download_login_failed": "登录失败: 请检查您的 Cookie 或账户信息后重试",
   "download_prompt_parse": "结束...",
   "download_book_ids": "要处理的一个或多个小说 ID",
   "download_option_start": "起始章节 ID (仅用于第一个书籍 ID)",
@@ -117,6 +118,8 @@
   "help_search": "在一个或多个站点搜索书籍",
   "help_search_sites": "要搜索的站点键 (默认为全部)",
   "help_search_keyword": "要搜索的关键字",
+  "help_search_limit": "总体搜索结果数量上限",
+  "help_search_site_limit": "单站点搜索结果数量上限",
   "no_results": "未找到结果",
   "prompt_select_index": "通过编号选择结果 (或按回车取消): ",
   "invalid_selection": "无效选择, 请重试。"

--- a/src/novel_downloader/locales/zh.json
+++ b/src/novel_downloader/locales/zh.json
@@ -58,6 +58,7 @@
   "download_site_mode": "使用模式: {mode}",
   "download_no_ids": "未提供书籍 ID, 正在退出",
   "download_fail_get_ids": "从配置获取书籍 ID 失败: {err}",
+  "download_config_load_fail": "加载配置失败: {err}",
   "download_only_example": "只发现示例书籍 ID (例如 '{example}')",
   "download_edit_config": "请编辑配置并将示例 ID 替换为真实书籍 ID",
   "download_downloading": "正在从 {site} 下载书籍 {book_id}...",
@@ -111,5 +112,12 @@
   "export_success_txt": "成功将 {book_id} 导出为 TXT。",
   "export_failed_txt": "导出 {book_id} 为 TXT 失败: {err}",
   "export_success_epub": "成功将 {book_id} 导出为 EPUB",
-  "export_failed_epub": "导出 {book_id} 为 EPUB 失败: {err}"
+  "export_failed_epub": "导出 {book_id} 为 EPUB 失败: {err}",
+
+  "help_search": "在一个或多个站点搜索书籍",
+  "help_search_sites": "要搜索的站点键 (默认为全部)",
+  "help_search_keyword": "要搜索的关键字",
+  "no_results": "未找到结果",
+  "prompt_select_index": "通过编号选择结果 (或按回车取消): ",
+  "invalid_selection": "无效选择, 请重试。"
 }

--- a/src/novel_downloader/models/__init__.py
+++ b/src/novel_downloader/models/__init__.py
@@ -15,6 +15,7 @@ from .config import (
     TextCleanerConfig,
 )
 from .login import LoginField
+from .search import SearchResult
 from .types import (
     BrowserType,
     LogLevel,
@@ -31,6 +32,7 @@ __all__ = [
     "TextCleanerConfig",
     "ChapterDict",
     "LoginField",
+    "SearchResult",
     "BrowserType",
     "ModeType",
     "SplitMode",

--- a/src/novel_downloader/models/search.py
+++ b/src/novel_downloader/models/search.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+"""
+novel_downloader.models.search
+------------------------------
+
+"""
+
+from typing import TypedDict
+
+
+class SearchResult(TypedDict, total=True):
+    site: str
+    book_id: str
+    title: str
+    author: str
+    priority: int


### PR DESCRIPTION
### Description

This PR introduces a unified **search** module to let users discover novels by keyword before downloading.

It defines a `BaseSearcher` abstraction, implements and registers site-specific searchers (`BiqugeSearcher`, `EsjzoneSearcher`, `QianbiSearcher`), exposes a top-level `search` function that queries all registered searchers, adds a new CLI `search` subcommand (with `--site`, `--limit`, `--site-limit` and `--config` flags).

---

### Changes

* **Core**:

  * Add `BaseSearcher` abstract class and `register_searcher` registry.
  * Implement `BiqugeSearcher`, `EsjzoneSearcher`, `QianbiSearcher` and register them.
  * Add `search(keyword, sites, limit, per_site_limit)` function to dispatch to all registered searchers.

* **CLI**:

  * Register new `search` subcommand in `cli/search.py`.
  * Support flags: `--site`/`-s`, `--limit`/`-l`, `--site-limit`, `--config`.
  * Wire `handle_search` to enforce `max(1, limit)` and `max(1, site_limit)`.

* **Docs**:

  * Update CLI reference with `search` usage, flags, and examples.
  * Add `Searchers` API section (import, parameters, return type, code samples).

---

### Motivation

Allowing users to search for novels by keyword across multiple sites greatly improves discoverability and workflow. Instead of requiring manual lookup of book IDs, this feature streamlines the process: search -> pick a result -> download.

---

### Type of change

* [x] New feature (adds functionality)
* [x] This change requires a documentation update
